### PR TITLE
Classify Keyring

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.29.33"
+  "version": "0.30.0"
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "@polkadot/dev": "^0.20.19",
-    "@polkadot/ts": "^0.1.25"
+    "@polkadot/ts": "^0.1.27"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/db",
-  "version": "0.29.33",
+  "version": "0.30.0",
   "description": "Implementation of a basic sync in-memory and on-disk databases with overlays",
   "main": "index.js",
   "keywords": [
@@ -29,8 +29,8 @@
   "homepage": "https://github.com/polkadot-js/common/tree/master/packages/db#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/trie-hash": "^0.29.33",
-    "@polkadot/util": "^0.29.33",
+    "@polkadot/trie-hash": "^0.30.0",
+    "@polkadot/util": "^0.30.0",
     "@types/mkdirp": "^0.5.2",
     "@types/snappy": "^6.0.0",
     "lru_map": "^0.3.3",

--- a/packages/trie-db/package.json
+++ b/packages/trie-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/trie-db",
-  "version": "0.29.33",
+  "version": "0.30.0",
   "description": "This is an implementation of the modified merkle patricia tree as speficed in Ethereum's yellow paper, adpated for Polkadot",
   "main": "index.js",
   "keywords": [
@@ -29,13 +29,13 @@
   "homepage": "https://github.com/polkadot-js/common/tree/master/packages/trie-db#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/trie-hash": "^0.29.33",
-    "@polkadot/util": "^0.29.33",
-    "@polkadot/util-crypto": "^0.29.33",
-    "@polkadot/util-rlp": "^0.29.33"
+    "@polkadot/trie-hash": "^0.30.0",
+    "@polkadot/util": "^0.30.0",
+    "@polkadot/util-crypto": "^0.30.0",
+    "@polkadot/util-rlp": "^0.30.0"
   },
   "devDependencies": {
-    "@polkadot/db": "^0.29.33",
+    "@polkadot/db": "^0.30.0",
     "ethereumjs-testing": "1.0.4"
   }
 }

--- a/packages/trie-hash/package.json
+++ b/packages/trie-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/trie-hash",
-  "version": "0.29.33",
+  "version": "0.30.0",
   "description": "Creation of triehash values",
   "main": "index.js",
   "keywords": [
@@ -29,8 +29,8 @@
   "homepage": "https://github.com/polkadot-js/common/tree/master/packages/trie-hash#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/util": "^0.29.33",
-    "@polkadot/util-crypto": "^0.29.33",
-    "@polkadot/util-rlp": "^0.29.33"
+    "@polkadot/util": "^0.30.0",
+    "@polkadot/util-crypto": "^0.30.0",
+    "@polkadot/util-rlp": "^0.30.0"
   }
 }

--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/util-crypto",
-  "version": "0.29.33",
+  "version": "0.30.0",
   "description": "A collection of useful crypto utilities for @polkadot",
   "main": "index.js",
   "keywords": [
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/polkadot-js/common/tree/master/packages/util-crypto#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/util": "^0.29.33",
+    "@polkadot/util": "^0.30.0",
     "blakejs": "^1.1.0",
     "js-sha3": "^0.8.0",
     "tweetnacl": "^1.0.0",

--- a/packages/util-keyring/package.json
+++ b/packages/util-keyring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/util-keyring",
-  "version": "0.29.33",
+  "version": "0.30.0",
   "description": "Keyring management",
   "main": "index.js",
   "engines": {
@@ -31,8 +31,8 @@
   "homepage": "https://github.com/polkadot-js/client/tree/master/packages/util-keyring#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/util": "^0.29.33",
-    "@polkadot/util-crypto": "^0.29.33",
+    "@polkadot/util": "^0.30.0",
+    "@polkadot/util-crypto": "^0.30.0",
     "@types/bs58": "^3.0.30",
     "bs58": "^4.0.1"
   }

--- a/packages/util-keyring/src/index.spec.js
+++ b/packages/util-keyring/src/index.spec.js
@@ -5,7 +5,7 @@
 import hexToU8a from '@polkadot/util/hex/toU8a';
 import u8aFromString from '@polkadot/util/u8a/fromString';
 
-import index from './index';
+import Keyring from './index';
 
 describe('keypair', () => {
   const publicKeyOne = new Uint8Array([47, 140, 97, 41, 216, 22, 207, 81, 195, 116, 188, 127, 8, 195, 230, 62, 209, 86, 207, 120, 174, 251, 74, 101, 80, 217, 123, 135, 153, 121, 119, 238]);
@@ -15,7 +15,7 @@ describe('keypair', () => {
   let keypair;
 
   beforeEach(() => {
-    keypair = index();
+    keypair = new Keyring();
 
     keypair.addFromSeed(seedOne);
   });

--- a/packages/util-keyring/src/pairs.ts
+++ b/packages/util-keyring/src/pairs.ts
@@ -17,35 +17,41 @@ type KeyringPairMap = {
   [index: Uint8Array]: KeyringPair
 };
 
-export default function pairs (): KeyringPairs {
-  const self: KeyringPairMap = {};
+export default class Pairs implements KeyringPairs {
+  private _map: KeyringPairMap;
 
-  return {
-    add: (pair: KeyringPair): KeyringPair => {
-      // @ts-ignore we use coercion :(
-      self[pair.publicKey()] = pair;
+  constructor () {
+    this._map = {};
+  }
 
-      return pair;
-    },
-    all: (): Array<KeyringPair> =>
-      Object.values(self),
-    get: (address: string | Uint8Array): KeyringPair => {
-      // @ts-ignore we use coercion :(
-      const pair = self[addressDecode(address)];
+  add (pair: KeyringPair): KeyringPair {
+    // @ts-ignore we use coercion :(
+    this._map[pair.publicKey()] = pair;
 
-      assert(pair, () => {
-        const formatted: string = isU8a(address) || isHex(address)
-          ? u8aToHex(u8aToU8a(address))
-          : address;
+    return pair;
+  }
 
-        return `Unable to retrieve keypair '${formatted}'`;
-      });
+  all (): Array<KeyringPair> {
+    return Object.values(this._map);
+  }
 
-      return pair;
-    },
-    remove: (address: string | Uint8Array): void => {
-      // @ts-ignore we use coercion :(
-      delete self[addressDecode(address)];
-    }
-  };
+  get (address: string | Uint8Array): KeyringPair {
+    // @ts-ignore we use coercion :(
+    const pair = this._map[addressDecode(address)];
+
+    assert(pair, () => {
+      const formatted: string = isU8a(address) || isHex(address)
+        ? u8aToHex(u8aToU8a(address))
+        : address;
+
+      return `Unable to retrieve keypair '${formatted}'`;
+    });
+
+    return pair;
+  }
+
+  remove (address: string | Uint8Array): void {
+    // @ts-ignore we use coercion :(
+    delete this._map[addressDecode(address)];
+  }
 }

--- a/packages/util-keyring/src/testing.ts
+++ b/packages/util-keyring/src/testing.ts
@@ -7,7 +7,7 @@ import { KeyringInstance } from './types';
 import hexToU8a from '@polkadot/util/hex/toU8a';
 import u8aFromString from '@polkadot/util/u8a/fromString';
 
-import createKeyring from './index';
+import Keyring from './index';
 
 function padSeed (seed: string): Uint8Array {
   return u8aFromString(seed.padEnd(32, ' '));
@@ -33,7 +33,7 @@ const SEEDS: { [index: string ]: Uint8Array } = {
 };
 
 export default function testKeyring (): KeyringInstance {
-  const keyring = createKeyring();
+  const keyring = new Keyring();
 
   Object
     .keys(SEEDS)

--- a/packages/util-keyring/src/types.d.ts
+++ b/packages/util-keyring/src/types.d.ts
@@ -31,14 +31,14 @@ export type KeyringPair = {
   verify (message: Uint8Array, signature: Uint8Array): boolean
 };
 
-export type KeyringPairs = {
+export interface KeyringPairs {
   add: (pair: KeyringPair) => KeyringPair,
   all: () => Array<KeyringPair>,
   get: (address: string | Uint8Array) => KeyringPair,
   remove: (address: string | Uint8Array) => void
-};
+}
 
-export type KeyringInstance = {
+export interface KeyringInstance {
   addFromAddress (address: string | Uint8Array, meta?: KeyringPair$Meta): KeyringPair,
   addFromSeed (seed: Uint8Array, meta?: KeyringPair$Meta): KeyringPair,
   addFromJson (pair: KeyringPair$Json): KeyringPair,
@@ -47,4 +47,4 @@ export type KeyringInstance = {
   getPublicKeys (): Array<Uint8Array>,
   removePair (address: string | Uint8Array): void,
   toJson (address: string | Uint8Array, passphrase?: string): KeyringPair$Json
-};
+}

--- a/packages/util-rlp/package.json
+++ b/packages/util-rlp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/util-rlp",
-  "version": "0.29.33",
+  "version": "0.30.0",
   "description": "RLP encoding and decoding",
   "main": "index.js",
   "keywords": [
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/polkadot-js/common/tree/master/packages/trie-hash#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/util": "^0.29.33"
+    "@polkadot/util": "^0.30.0"
   },
   "devDependencies": {
     "ethereumjs-testing": "1.0.4"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/util",
-  "version": "0.29.33",
+  "version": "0.30.0",
   "description": "A collection of useful utilities for @polkadot",
   "main": "index.js",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,9 +1210,9 @@
     typedoc-plugin-markdown "^1.1.15"
     typescript "^3.0.1"
 
-"@polkadot/ts@^0.1.25":
-  version "0.1.25"
-  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.25.tgz#a88c5242ae02975acce7128b5a84a6df8ca9d7b7"
+"@polkadot/ts@^0.1.27":
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.27.tgz#88ddd9e90f4c5c98996ecd433670839eaf530d73"
 
 "@types/base-x@*":
   version "1.0.29"


### PR DESCRIPTION
Aligns and simplifies use of Keyring with the rest of the interfaces where closures have been converted to ES6 objects. (e.g. large parts of the API)

Going from 

```
import createKeyring from '@polkadot/util-keyring';

const keyring = createKeyring();
const pair = keyring.addFromSeed(<some_seed>);
const signature = pair.sign(<some_message>);
```

to new version -

```
import Keyring from '@polkadot/util-keyring';

const keyring = new Keyring();
const pair = keyring.addFromSeed(<some_seed>);
const signature = pair.sign(<some_message>);
```

There will be work on the UI side now as well to implement this is ui-keyring. (Probably inherit from object and add the new methods?)

cc @chevdor 
cc @ltfschoen 