### PR TITLE
refactor: Extension of #231. Destructuring to combine imports

### DIFF
--- a/docs/examples/util-crypto/01_encrypt_decrypt_message_nacl/index.js
+++ b/docs/examples/util-crypto/01_encrypt_decrypt_message_nacl/index.js
@@ -1,5 +1,4 @@
-const { naclEncrypt } = require('@polkadot/util-crypto');
-const { naclDecrypt } = require('@polkadot/util-crypto');
+const { naclEncrypt, naclDecrypt } = require('@polkadot/util-crypto');
 
 async function main () {
   const secret = new Uint8Array(32);

--- a/docs/examples/util-crypto/02_sign_verify_message_nacl/index.js
+++ b/docs/examples/util-crypto/02_sign_verify_message_nacl/index.js
@@ -1,5 +1,6 @@
 const { stringToU8a, u8aToHex } = require('@polkadot/util');
-const { naclEncrypt, naclKeypairFromSeed, naclSign, naclVerify, randomAsU8a
+const {
+  naclEncrypt, naclKeypairFromSeed, naclSign, naclVerify, randomAsU8a
 } = require('@polkadot/util-crypto');
 
 async function main () {

--- a/docs/examples/util-crypto/02_sign_verify_message_nacl/index.js
+++ b/docs/examples/util-crypto/02_sign_verify_message_nacl/index.js
@@ -1,10 +1,6 @@
-const stringToU8a = require('@polkadot/util/string/toU8a').default;
-const { randomAsU8a } = require('@polkadot/util-crypto');
-
-const { naclKeypairFromSeed } = require('@polkadot/util-crypto');
-const { naclEncrypt } = require('@polkadot/util-crypto');
-const { naclSign } = require('@polkadot/util-crypto');
-const { naclVerify } = require('@polkadot/util-crypto');
+const { stringToU8a, u8aToHex } = require('@polkadot/util');
+const { naclEncrypt, naclKeypairFromSeed, naclSign, naclVerify, randomAsU8a
+} = require('@polkadot/util-crypto');
 
 async function main () {
   // Create account seed for Alice as fallback if generated mnemonic not valid
@@ -22,6 +18,7 @@ async function main () {
 
   // Sign the message with a valid signature
   const messageSignature = naclSign(encrypted, secretKey);
+  console.log(`Message signature: ${u8aToHex(messageSignature)}`);
 
   // Validate that the message was correctly signed
   const isValidSignature = naclVerify(encrypted, messageSignature, publicKey);

--- a/docs/examples/util-crypto/03_mnemonic_generate_validate_bip39/index.js
+++ b/docs/examples/util-crypto/03_mnemonic_generate_validate_bip39/index.js
@@ -1,4 +1,5 @@
-const { mnemonicGenerate, mnemonicToSeed, mnemonicValidate, naclKeypairFromSeed
+const {
+  mnemonicGenerate, mnemonicToSeed, mnemonicValidate, naclKeypairFromSeed
 } = require('@polkadot/util-crypto');
 
 async function main () {

--- a/docs/examples/util-crypto/03_mnemonic_generate_validate_bip39/index.js
+++ b/docs/examples/util-crypto/03_mnemonic_generate_validate_bip39/index.js
@@ -1,12 +1,11 @@
-const { mnemonicGenerate } = require('@polkadot/util-crypto');
-const { mnemonicToSeed } = require('@polkadot/util-crypto');
-const { mnemonicValidate } = require('@polkadot/util-crypto');
-const { toSecret } = require('@polkadot/util-crypto');
-const { naclKeypairFromSeed } = require('@polkadot/util-crypto');
+const { mnemonicGenerate, mnemonicToSeed, mnemonicValidate, naclKeypairFromSeed
+} = require('@polkadot/util-crypto');
 
 async function main () {
   // Create mnemonic string for Alice using BIP39
   const mnemonicAlice = mnemonicGenerate();
+
+  console.log(`Generated mnemonic: ${mnemonicAlice}`);
 
   // Validate the mnemic string that was generated
   const isValidMnemonic = mnemonicValidate(mnemonicAlice);


### PR DESCRIPTION
* Instead of multiple lines to import from the same library:

<img width="665" alt="screen shot 2018-10-19 at 18 24 35" src="https://user-images.githubusercontent.com/6226175/47231081-3f161100-d3cc-11e8-9f44-a84288d841c4.png">

Use destructuring to import them more concisely:

<img width="690" alt="screen shot 2018-10-19 at 18 28 18" src="https://user-images.githubusercontent.com/6226175/47231302-cfecec80-d3cc-11e8-9a06-9d59c99d25b2.png">

* Avoids use of `.default` in imports. Instead of `const stringToU8a = require('@polkadot/util/string/toU8a').default;`, changed to `const { stringToU8a, u8aToHex } = require('@polkadot/util');`

* Added extra console.logs in the code so the user can see the output of whats going on

