### PR TITLE
isString true for String object

### DIFF
--- a/packages/util/src/is/hex.spec.js
+++ b/packages/util/src/is/hex.spec.js
@@ -19,6 +19,13 @@ describe('isHex', () => {
     ).toEqual(true);
   });
 
+
+  it('returns true on hex values with String', () => {
+    expect(
+      isHex(new String(`0x${test}`))
+    ).toEqual(true);
+  });
+
   it('returns false on hex values (non % 2)', () => {
     expect(
       isHex(`0x${test}0`)

--- a/packages/util/src/is/hex.ts
+++ b/packages/util/src/is/hex.ts
@@ -22,9 +22,8 @@ const HEX_REGEX = /^0x[a-fA-F0-9]+$/;
  * isHex('0x1234', 8); // => false
  * ```
  */
-export default function isHex (_value: any, bitLength: number = -1, ignoreLength: boolean = false): _value is string | String {
-  const value = (_value as string);
-  const isValidHex = value === '0x' || (isString(value) && HEX_REGEX.test(value));
+export default function isHex (value: any, bitLength: number = -1, ignoreLength: boolean = false): value is string | String {
+  const isValidHex = value === '0x' || (isString(value) && HEX_REGEX.test(value.toString()));
 
   if (isValidHex && bitLength !== -1) {
     return value.length === (2 + Math.ceil(bitLength / 4));

--- a/packages/util/src/is/hex.ts
+++ b/packages/util/src/is/hex.ts
@@ -22,7 +22,7 @@ const HEX_REGEX = /^0x[a-fA-F0-9]+$/;
  * isHex('0x1234', 8); // => false
  * ```
  */
-export default function isHex (_value: any, bitLength: number = -1, ignoreLength: boolean = false): boolean {
+export default function isHex (_value: any, bitLength: number = -1, ignoreLength: boolean = false): _value is string | String {
   const value = (_value as string);
   const isValidHex = value === '0x' || (isString(value) && HEX_REGEX.test(value));
 

--- a/packages/util/src/is/string.spec.js
+++ b/packages/util/src/is/string.spec.js
@@ -17,6 +17,12 @@ describe('isString', () => {
     ).toEqual(true);
   });
 
+  it('returns true on String object', () => {
+    expect(
+      isString(new String('foo'))
+    ).toEqual(true);
+  });
+
   it('returns false on invalid numbers', () => {
     expect(
       isString(2)

--- a/packages/util/src/is/string.ts
+++ b/packages/util/src/is/string.ts
@@ -18,5 +18,5 @@
  * ```
  */
 export default function isString (value: any): value is string {
-  return typeof value === 'string';
+  return typeof value === 'string' || value instanceof String;
 }

--- a/packages/util/src/is/string.ts
+++ b/packages/util/src/is/string.ts
@@ -17,6 +17,6 @@
  * console.log('isString', isString('test')); // => true
  * ```
  */
-export default function isString (value: any): value is string {
+export default function isString (value: any): value is string | String {
   return typeof value === 'string' || value instanceof String;
 }


### PR DESCRIPTION
We'll have in the api `class Text extends String`. Instead of writing everywhere `if (isString(value) || value instanceof String)`, I prefer to factorize it here.