### PR TITLE
Parsing function for JSON objects

### DIFF
--- a/packages/util/src/is/index.ts
+++ b/packages/util/src/is/index.ts
@@ -14,6 +14,7 @@ export { default as isFunction } from './function';
 export { default as isHex } from './hex';
 export { default as isInstanceOf } from './instanceOf';
 export { default as isIp } from './ip';
+export { default as isJsonObject } from './jsonObject';
 export { default as isNull } from './null';
 export { default as isNumber } from './number';
 export { default as isObject } from './object';

--- a/packages/util/src/is/jsonObject.spec.ts
+++ b/packages/util/src/is/jsonObject.spec.ts
@@ -1,0 +1,51 @@
+// Copyright 2017-2019 @polkadot/util authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { isJsonObject } from './index';
+
+const jsonObject = `{
+    "Test": "1234",
+    "NestedTest": {
+      "Test": "5678"
+    }
+  }`;
+
+describe('isJsonObject', () => {
+
+  it('returns true on empty objects', () => {
+    expect(
+      isJsonObject({})
+    ).toEqual(true);
+  });
+
+  it('returns true on JSON objects', () => {
+    expect(
+      isJsonObject(jsonObject)
+    ).toEqual(true);
+  });
+
+  it('returns false on valid JSON but typeof number', () => {
+    expect(
+      isJsonObject(1234)
+    ).toEqual(false);
+  });
+
+  it('returns false on valid JSON but null', () => {
+    expect(
+      isJsonObject(null)
+    ).toEqual(false);
+  });
+
+  it('returns false on invalid objects', () => {
+    expect(
+      isJsonObject('notAnObject')
+    ).toEqual(false);
+  });
+
+  it('returns false on invalid JSON', () => {
+    expect(
+      isJsonObject(`{"abc", "def"}`)
+    ).toEqual(false);
+  });
+});

--- a/packages/util/src/is/jsonObject.spec.ts
+++ b/packages/util/src/is/jsonObject.spec.ts
@@ -12,7 +12,6 @@ const jsonObject = `{
   }`;
 
 describe('isJsonObject', () => {
-
   it('returns true on empty objects', () => {
     expect(
       isJsonObject({})

--- a/packages/util/src/is/jsonObject.spec.ts
+++ b/packages/util/src/is/jsonObject.spec.ts
@@ -25,13 +25,13 @@ describe('isJsonObject', () => {
     ).toEqual(true);
   });
 
-  it('returns false on valid JSON but typeof number', () => {
+  it('returns false on JSON parsable value typeof number', () => {
     expect(
       isJsonObject(1234)
     ).toEqual(false);
   });
 
-  it('returns false on valid JSON but null', () => {
+  it('returns false on JSON parsable value null', () => {
     expect(
       isJsonObject(null)
     ).toEqual(false);

--- a/packages/util/src/is/jsonObject.ts
+++ b/packages/util/src/is/jsonObject.ts
@@ -30,14 +30,16 @@ type ObjectIndexed = {
  * isJsonObject('not an object'); // => false
  * ```
  */
+
 export default function isJsonObject (value: any): value is ObjectIndexed {
 
   value = typeof value !== 'string'
-  ? JSON.stringify(value)
-  : value;
+    ? JSON.stringify(value)
+    : value;
 
   try {
     value = JSON.parse(value);
+
     return (typeof value === 'object' && value !== null);
   } catch (e) {
     return false;

--- a/packages/util/src/is/jsonObject.ts
+++ b/packages/util/src/is/jsonObject.ts
@@ -1,0 +1,45 @@
+// Copyright 2017-2019 @polkadot/util authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+type ObjectIndexed = {
+  [index: string]: any
+};
+
+/**
+ * @name isJsonObject
+ * @summary Tests for a valid JSON `object`.
+ * @description
+ * Checks to see if the input value is a valid JSON object.
+ * It returns false if the input is valid JSON, but not an Javascript object.
+ * @example
+ * <BR>
+ *
+ * ```javascript
+ * import { isJsonObject } from '@polkadot/util';
+ *
+ * isJsonObject({}); // => true
+ * isJsonObject({
+ *  "Test": "1234",
+ *  "NestedTest": {
+ *   "Test": "5678"
+ *  }
+ * }); // => true
+ * isJsonObject(1234); // valid JSON, but not an object =>  false
+ * isJsonObject(null); // valid JSON, but not an object => false
+ * isJsonObject('not an object'); // => false
+ * ```
+ */
+export default function isJsonObject (value: any): value is ObjectIndexed {
+
+  value = typeof value !== 'string'
+  ? JSON.stringify(value)
+  : value;
+
+  try {
+    value = JSON.parse(value);
+    return (typeof value === 'object' && value !== null);
+  } catch (e) {
+    return false;
+  }
+}

--- a/packages/util/src/is/jsonObject.ts
+++ b/packages/util/src/is/jsonObject.ts
@@ -11,7 +11,7 @@ type ObjectIndexed = {
  * @summary Tests for a valid JSON `object`.
  * @description
  * Checks to see if the input value is a valid JSON object.
- * It returns false if the input is valid JSON, but not an Javascript object.
+ * It returns false if the input is JSON parsable, but not an Javascript object.
  * @example
  * <BR>
  *
@@ -25,8 +25,8 @@ type ObjectIndexed = {
  *   "Test": "5678"
  *  }
  * }); // => true
- * isJsonObject(1234); // valid JSON, but not an object =>  false
- * isJsonObject(null); // valid JSON, but not an object => false
+ * isJsonObject(1234); // JSON parsable, but not an object =>  false
+ * isJsonObject(null); // JSON parsable, but not an object => false
  * isJsonObject('not an object'); // => false
  * ```
  */


### PR DESCRIPTION
 Checks to see if the input value is a valid JSON object.
 It returns false if the input is JSON parsable, but not an Javascript object.

Use-cases:
- To validate if uploaded files contain valid JSON objects
- To validate if manual code input in editors contains valid JSON objects 