### PR TITLE
Shortcut for creating dev accounts

### DIFF
--- a/packages/keyring/src/defaults.ts
+++ b/packages/keyring/src/defaults.ts
@@ -1,0 +1,14 @@
+// Copyright 2017-2019 @polkadot/keyring authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+// default substrate dev phrase
+const DEV_PHRASE = 'bottom drive obey lake curtain smoke basket hold race lonely fit walk';
+
+// seed from the above phrase
+const DEV_SEED = '0xfac7959dbfe72f052e5a0c3c8d6530f202b02fd8f9f5ca3580ec8deb7797479e';
+
+export {
+  DEV_PHRASE,
+  DEV_SEED
+};

--- a/packages/keyring/src/index.spec.ts
+++ b/packages/keyring/src/index.spec.ts
@@ -21,8 +21,6 @@ describe('keypair', () => {
     let keypair: Keyring;
 
     beforeEach(async () => {
-      await cryptoWaitReady();
-
       keypair = new Keyring({ type: 'ed25519' });
 
       keypair.addFromSeed(seedOne, {});
@@ -86,6 +84,12 @@ describe('keypair', () => {
       keypair = new Keyring({ type: 'sr25519' });
 
       keypair.addFromSeed(seedOne, {});
+    });
+
+    it('creates with dev phrase when only path specified', () => {
+      expect(
+        keypair.createFromUri('//Alice').address()
+      ).toEqual('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKv3gB');
     });
 
     it('adds the pair', () => {

--- a/packages/keyring/src/index.ts
+++ b/packages/keyring/src/index.ts
@@ -9,6 +9,7 @@ import { assert, hexToU8a, isNumber, isHex, stringToU8a } from '@polkadot/util';
 import { keyExtractSuri, mnemonicToSeed , naclKeypairFromSeed as naclFromSeed, schnorrkelKeypairFromSeed as schnorrkelFromSeed, mnemonicToMiniSecret, keyFromPath } from '@polkadot/util-crypto';
 
 import { decodeAddress, encodeAddress, setAddressPrefix } from './address';
+import { DEV_PHRASE } from './defaults';
 import createPair from './pair';
 import Pairs from './pairs';
 
@@ -145,7 +146,10 @@ export default class Keyring implements KeyringInstance {
    * @summry Creates a Keypair from an suri
    * @description This creates a pair from the suri, but does not add it to the keyring
    */
-  createFromUri (suri: string, meta: KeyringPair$Meta = {}, type: KeypairType = this.type): KeyringPair {
+  createFromUri (_suri: string, meta: KeyringPair$Meta = {}, type: KeypairType = this.type): KeyringPair {
+    const suri = _suri.indexOf('//') === 0
+      ? `${DEV_PHRASE}${_suri}`
+      : _suri;
     const { password, phrase, path } = keyExtractSuri(suri);
     let seed;
 

--- a/packages/keyring/src/testing.ts
+++ b/packages/keyring/src/testing.ts
@@ -10,9 +10,6 @@ import createPair from './pair';
 import Keyring from '.';
 
 // As per substrate
-// const DEV_PHRASE = 'bottom drive obey lake curtain smoke basket hold race lonely fit walk';
-// created from the above
-// const DEV_SEED = '0xfac7959dbfe72f052e5a0c3c8d6530f202b02fd8f9f5ca3580ec8deb7797479e';
 const SEEDS = ['Alice', 'Bob', 'Charlie', 'Dave', 'Eve', 'Ferdie'];
 // NOTE This is not great, but a testing keyring is for testing - what happens is that in most cases
 // the keyring is initialises before anythign else. Since the sr25519 crypto is async, this creates


### PR DESCRIPTION
Align with subkey, i.e. when `//Alice` is specified as an suri, auto-add the `<dev-phrase>` so the suri becomes `<dev-phrase>//Alice`

cc @drewstone