### PR TITLE
use typeof window (for global detection)

### DIFF
--- a/packages/util/src/assertSingletonPackage.ts
+++ b/packages/util/src/assertSingletonPackage.ts
@@ -10,6 +10,7 @@ import assert from './assert';
  * @summary Checks that a specific package is only imported once
  */
 export default function assertSingletonPackage (name: string): void {
+  // tslint:disable-next-line
   const _global: any = typeof window !== 'undefined'
     ? window
     : global;

--- a/packages/util/src/assertSingletonPackage.ts
+++ b/packages/util/src/assertSingletonPackage.ts
@@ -10,9 +10,11 @@ import assert from './assert';
  * @summary Checks that a specific package is only imported once
  */
 export default function assertSingletonPackage (name: string): void {
-  const _global: any = isUndefined(window) ? global : window;
+  const _global: any = typeof window !== 'undefined'
+    ? window
+    : global;
 
-  if (isUndefined(_global.__polkadotjs)) {
+  if (!_global.__polkadotjs) {
     _global.__polkadotjs = {};
   }
 


### PR DESCRIPTION
Currently this happens -

```
$ ts-node cli.ts --help

/home/user/cw/edgeware-apps/node_modules/@polkadot/types/node_modules/@polkadot/util/assertSingletonPackage.js:23
  const _global = (0, _undefined.default)(window) ? global : window;

                               ^
ReferenceError: window is not defined

```
