### PR TITLE
Allow string params for sr25519/ed25519 sign & verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.91.1
+
+- ed25519/sr25519 sign & verify functions can now take the message input as Uint8Array/string/hex and verify allows for the signature/publicKey to be specified as Uint8Array/hex
+- Update `@polkadot/wasm` to include a maintenace bump for the `w3f/schnorrkel` libraries
+
 # 0.90.1
 
 - Moving towards 1.0

--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "@polkadot/util": "^0.90.1",
-    "@polkadot/wasm-crypto": "^0.9.1",
+    "@polkadot/wasm-crypto": "^0.10.1",
     "@types/bip39": "^2.4.2",
     "@types/pbkdf2": "^3.0.0",
     "@types/secp256k1": "^3.5.0",

--- a/packages/util-crypto/src/nacl/sign.ts
+++ b/packages/util-crypto/src/nacl/sign.ts
@@ -22,12 +22,12 @@ import { isReady, ed25519Sign } from '@polkadot/wasm-crypto';
  * naclSign([...], [...]); // => [...]
  * ```
  */
-export default function naclSign (_message: Uint8Array | string, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
+export default function naclSign (message: Uint8Array | string, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
   assert(secretKey, 'Expected valid secretKey');
 
-  const message = u8aToU8a(_message);
+  const messageU8a = u8aToU8a(message);
 
   return isReady()
-    ? ed25519Sign(publicKey as Uint8Array, (secretKey as Uint8Array).subarray(0, 32), message)
-    : nacl.sign.detached(message, secretKey as Uint8Array);
+    ? ed25519Sign(publicKey as Uint8Array, (secretKey as Uint8Array).subarray(0, 32), messageU8a)
+    : nacl.sign.detached(messageU8a, secretKey as Uint8Array);
 }

--- a/packages/util-crypto/src/nacl/sign.ts
+++ b/packages/util-crypto/src/nacl/sign.ts
@@ -5,7 +5,7 @@
 import { Keypair } from '../types';
 
 import nacl from 'tweetnacl';
-import { assert } from '@polkadot/util';
+import { assert, u8aToU8a } from '@polkadot/util';
 import { isReady, ed25519Sign } from '@polkadot/wasm-crypto';
 
 /**
@@ -22,8 +22,10 @@ import { isReady, ed25519Sign } from '@polkadot/wasm-crypto';
  * naclSign([...], [...]); // => [...]
  * ```
  */
-export default function naclSign (message: Uint8Array, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
+export default function naclSign (_message: Uint8Array | string, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
   assert(secretKey, 'Expected valid secretKey');
+
+  const message = u8aToU8a(_message);
 
   return isReady()
     ? ed25519Sign(publicKey as Uint8Array, (secretKey as Uint8Array).subarray(0, 32), message)

--- a/packages/util-crypto/src/nacl/verify.ts
+++ b/packages/util-crypto/src/nacl/verify.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import nacl from 'tweetnacl';
+import { u8aToU8a } from '@polkadot/util';
 import { isReady, ed25519Verify } from '@polkadot/wasm-crypto';
 
 /**
@@ -19,7 +20,11 @@ import { isReady, ed25519Verify } from '@polkadot/wasm-crypto';
  * naclVerify([...], [...], [...]); // => true/false
  * ```
  */
-export default function naclVerify (message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array): boolean {
+export default function naclVerify (_message: Uint8Array | string, _signature: Uint8Array | string, _publicKey: Uint8Array | string): boolean {
+  const message = u8aToU8a(_message);
+  const signature = u8aToU8a(_signature);
+  const publicKey = u8aToU8a(_publicKey);
+
   return isReady()
     ? ed25519Verify(signature, message, publicKey)
     : nacl.sign.detached.verify(message, signature, publicKey);

--- a/packages/util-crypto/src/nacl/verify.ts
+++ b/packages/util-crypto/src/nacl/verify.ts
@@ -20,12 +20,12 @@ import { isReady, ed25519Verify } from '@polkadot/wasm-crypto';
  * naclVerify([...], [...], [...]); // => true/false
  * ```
  */
-export default function naclVerify (_message: Uint8Array | string, _signature: Uint8Array | string, _publicKey: Uint8Array | string): boolean {
-  const message = u8aToU8a(_message);
-  const signature = u8aToU8a(_signature);
-  const publicKey = u8aToU8a(_publicKey);
+export default function naclVerify (message: Uint8Array | string, signature: Uint8Array | string, publicKey: Uint8Array | string): boolean {
+  const messageU8a = u8aToU8a(message);
+  const signatureU8a = u8aToU8a(signature);
+  const publicKeyU8a = u8aToU8a(publicKey);
 
   return isReady()
-    ? ed25519Verify(signature, message, publicKey)
-    : nacl.sign.detached.verify(message, signature, publicKey);
+    ? ed25519Verify(signatureU8a, messageU8a, publicKeyU8a)
+    : nacl.sign.detached.verify(messageU8a, signatureU8a, publicKeyU8a);
 }

--- a/packages/util-crypto/src/schnorrkel/sign.ts
+++ b/packages/util-crypto/src/schnorrkel/sign.ts
@@ -13,11 +13,11 @@ import { sr25519Sign } from '@polkadot/wasm-crypto';
  * @name schnorrkelSign
  * @description Returns message signature of `message`, using the supplied pair
  */
-export default function schnorrkelSign (_message: Uint8Array | string, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
+export default function schnorrkelSign (message: Uint8Array | string, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
   assert(publicKey && publicKey.length === 32, 'Expected valid publicKey, 32-bytes');
   assert(secretKey && secretKey.length === 64, 'Expected valid secretKey, 64-bytes');
 
-  const message = u8aToU8a(_message);
+  const messageU8a = u8aToU8a(message);
 
-  return sr25519Sign(publicKey as Uint8Array, secretKey as Uint8Array, message);
+  return sr25519Sign(publicKey as Uint8Array, secretKey as Uint8Array, messageU8a);
 }

--- a/packages/util-crypto/src/schnorrkel/sign.ts
+++ b/packages/util-crypto/src/schnorrkel/sign.ts
@@ -6,16 +6,18 @@ import { Keypair } from '../types';
 
 import '../polyfill';
 
-import { assert } from '@polkadot/util';
+import { assert, u8aToU8a } from '@polkadot/util';
 import { sr25519Sign } from '@polkadot/wasm-crypto';
 
 /**
  * @name schnorrkelSign
  * @description Returns message signature of `message`, using the supplied pair
  */
-export default function schnorrkelSign (message: Uint8Array, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
+export default function schnorrkelSign (_message: Uint8Array | string, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
   assert(publicKey && publicKey.length === 32, 'Expected valid publicKey, 32-bytes');
   assert(secretKey && secretKey.length === 64, 'Expected valid secretKey, 64-bytes');
+
+  const message = u8aToU8a(_message);
 
   return sr25519Sign(publicKey as Uint8Array, secretKey as Uint8Array, message);
 }

--- a/packages/util-crypto/src/schnorrkel/verify.ts
+++ b/packages/util-crypto/src/schnorrkel/verify.ts
@@ -11,10 +11,10 @@ import { sr25519Verify } from '@polkadot/wasm-crypto';
  * @name schnorrkelVerify
  * @description Verifies the signature of `message`, using the supplied pair
  */
-export default function schnorrkelVerify (_message: Uint8Array | string, _signature: Uint8Array | string, _publicKey: Uint8Array | string): boolean {
-  const message = u8aToU8a(_message);
-  const signature = u8aToU8a(_signature);
-  const publicKey = u8aToU8a(_publicKey);
+export default function schnorrkelVerify (message: Uint8Array | string, signature: Uint8Array | string, publicKey: Uint8Array | string): boolean {
+  const messageU8a = u8aToU8a(message);
+  const signatureU8a = u8aToU8a(signature);
+  const publicKeyU8a = u8aToU8a(publicKey);
 
-  return sr25519Verify(signature, message, publicKey);
+  return sr25519Verify(signatureU8a, messageU8a, publicKeyU8a);
 }

--- a/packages/util-crypto/src/schnorrkel/verify.ts
+++ b/packages/util-crypto/src/schnorrkel/verify.ts
@@ -4,12 +4,17 @@
 
 import '../polyfill';
 
+import { u8aToU8a } from '@polkadot/util';
 import { sr25519Verify } from '@polkadot/wasm-crypto';
 
 /**
  * @name schnorrkelVerify
  * @description Verifies the signature of `message`, using the supplied pair
  */
-export default function schnorrkelVerify (message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array): boolean {
+export default function schnorrkelVerify (_message: Uint8Array | string, _signature: Uint8Array | string, _publicKey: Uint8Array | string): boolean {
+  const message = u8aToU8a(_message);
+  const signature = u8aToU8a(_signature);
+  const publicKey = u8aToU8a(_publicKey);
+
   return sr25519Verify(signature, message, publicKey);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1667,10 +1667,10 @@
   resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.56.tgz#ffd6e9c95704a7fb90b918193b9dc5c440114b27"
   integrity sha512-wnt4zXxZXyz6WaubTO/I+nUElwV2DogFzdl6CrKfVn2PTWp8uHN06W9s40FH57ORtmQfDr9rLRP8Nq+oIyElbg==
 
-"@polkadot/wasm-crypto@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-0.9.1.tgz#8c92fb3ab10a010d9894623958845b4047539d86"
-  integrity sha512-CBMzj71z5Stk0kvtpIMGHSTut9OJwscYkgPeyML14kJ1FLipm+p6qz83zXKqvMbPLiCBKXZwDpKiVlMwwmBaPA==
+"@polkadot/wasm-crypto@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-0.10.1.tgz#284e57e102050cca1586b7b1f008f64224147eb4"
+  integrity sha512-hI3OYftMGJkDetTe1DeU9aH4euk6WVmAMFszslNrCxHMFFkemEgACykwpyuOdCjv24VZP/cMsrVskKix1GzSYQ==
 
 "@types/babel__core@^7.1.0":
   version "7.1.1"


### PR DESCRIPTION
Would make sense to include the update from https://github.com/polkadot-js/wasm/pull/20 in here as well (non-functionality, but `w3f/schnorrkel` is bumped to 0.1.1 in there to align with substrate.

Based on feedback in actual use by @jnaviask