### PR TITLE
Add entries() method to trie

### DIFF
--- a/packages/trie-db/src/index.ts
+++ b/packages/trie-db/src/index.ts
@@ -4,7 +4,7 @@
 
 import { TxDb, ProgressCb } from '@polkadot/db/types';
 import { Codec } from '@polkadot/trie-codec/types';
-import { TrieDb, Node } from './types';
+import { TrieDb, Node, TrieEntry } from './types';
 
 import MemoryDb from '@polkadot/db/Memory';
 import { toNibbles } from '@polkadot/trie-codec/util';
@@ -121,16 +121,20 @@ export default class Trie extends Impl implements TrieDb {
     return this.rootHash;
   }
 
-  getNode (hash?: Uint8Array): Node {
-    return this._getNode(hash || this.rootHash);
-  }
-
   setRoot (rootHash: Uint8Array): void {
     this.rootHash = rootHash;
     // return this._setRootNode(rootNode);
   }
 
-  entries (): Array<[Uint8Array, Uint8Array]> {
+  getEntry (hash?: Uint8Array): TrieEntry | null {
+    return this._entry(hash || this.rootHash);
+  }
+
+  getNode (hash?: Uint8Array): Node {
+    return this._getNode(hash || this.rootHash);
+  }
+
+  entries (): Array<TrieEntry> {
     l.debug(() => 'retreiving trie entries');
 
     const start = Date.now();

--- a/packages/trie-db/src/index.ts
+++ b/packages/trie-db/src/index.ts
@@ -130,21 +130,28 @@ export default class Trie extends Impl implements TrieDb {
     // return this._setRootNode(rootNode);
   }
 
-  snapshot (dest: TrieDb, fn?: ProgressCb): number {
-    const start = Date.now();
+  entries (): Array<[Uint8Array, Uint8Array]> {
+    l.debug(() => 'retreiving trie entries');
 
+    const start = Date.now();
+    const entries = this._entries(this.rootHash);
+    const elapsed = (Date.now() - start) / 1000;
+
+    l.debug(() => `entries retrieved in ${elapsed.toFixed(2)}s, ${(entries.length / 1000).toFixed(2)}k keys`);
+
+    return entries;
+  }
+
+  snapshot (dest: TrieDb, fn?: ProgressCb): number {
     l.debug(() => 'creating current state snapshot');
 
+    const start = Date.now();
     const keys = this._snapshot(dest, fn, this.rootHash, 0, 0, 0);
     const elapsed = (Date.now() - start) / 1000;
 
     dest.setRoot(this.rootHash);
 
-    const newSize = dest.db.size();
-    const percentage = 100 * (newSize / this.db.size());
-    const sizeMB = newSize / (1024 * 1024);
-
-    l.debug(() => `snapshot created in ${elapsed.toFixed(2)}s, ${(keys / 1000).toFixed(2)}k keys, ${sizeMB.toFixed(2)}MB (${percentage.toFixed(2)}%)`);
+    l.debug(() => `snapshot created in ${elapsed.toFixed(2)}s, ${(keys / 1000).toFixed(2)}k keys`);
 
     fn && fn({
       isCompleted: true,

--- a/packages/trie-db/src/snapshot.spec.ts
+++ b/packages/trie-db/src/snapshot.spec.ts
@@ -62,7 +62,10 @@ describe('snapshots', () => {
 
     const entries = trie.entries();
 
-    entries.forEach(([key, encoded]) => back.db.put(key, encoded));
+    entries.forEach(([key, encoded, children]) => {
+      back.db.put(key, encoded);
+      console.log(u8aToHex(key), ...children.map((child) => `\n\t${u8aToHex(child)}`));
+    });
 
     back.setRoot(root);
 

--- a/packages/trie-db/src/types.ts
+++ b/packages/trie-db/src/types.ts
@@ -38,5 +38,6 @@ export interface TrieDb extends TxDb {
 
   getRoot (): Uint8Array;
   setRoot (rootHash: Uint8Array): void;
-  snapshot (dest: TrieDb, fn: ProgressCb): number;
+  entries (): Array<[Uint8Array, Uint8Array]>;
+  snapshot (dest: TrieDb, fn?: ProgressCb): number;
 }

--- a/packages/trie-db/src/types.ts
+++ b/packages/trie-db/src/types.ts
@@ -33,11 +33,18 @@ export type NodeNotEmpty = NodeKv | NodeBranch;
 
 export type Node = NodeEmpty | NodeNotEmpty;
 
+// root, encoded, childroots
+export type TrieEntry = [Uint8Array, Uint8Array, Array<Uint8Array>];
+
 export interface TrieDb extends TxDb {
   readonly db: TxDb;
 
   getRoot (): Uint8Array;
   setRoot (rootHash: Uint8Array): void;
-  entries (): Array<[Uint8Array, Uint8Array]>;
+
+  getEntry (root?: Uint8Array): TrieEntry | null;
+  getNode (hash?: Uint8Array): Node;
+
+  entries (): Array<TrieEntry>;
   snapshot (dest: TrieDb, fn?: ProgressCb): number;
 }


### PR DESCRIPTION
- optimize snapshot with one less encoding operation (retrieve raw & encoded, never decode and immediate re-encode)
- Add entries() to return Array<[root, encoded, ...childRoots]> - which can be used to re-construct
- Add getEntry(root?) to return [root, encoded, ...childRoots] - showing a root and all dependent roots