### PR TITLE
Handing high decimals scenes

### DIFF
--- a/packages/util/src/format/formatBalance.spec.ts
+++ b/packages/util/src/format/formatBalance.spec.ts
@@ -20,6 +20,12 @@ describe('formatBalance', (): void => {
     ).toEqual('123.456µ Unit');
   });
 
+  it('formats 123,456,789,000 (decimals=36)', (): void => {
+    expect(
+      formatBalance(TESTVAL, true, 36)
+    ).toEqual('0.123y Unit');
+  });
+
   it('formats 123,456,789,000 (decimals=15, Compact)', (): void => {
     const compact = {
       toBn: (): BN => TESTVAL,

--- a/packages/util/src/format/formatBalance.ts
+++ b/packages/util/src/format/formatBalance.ts
@@ -53,7 +53,8 @@ function _formatBalance <ExtToBn extends ToBn> (input?: number | string | BN | E
   const si = calcSi(text, decimals);
   const mid = text.length - (decimals + si.power);
   const prefix = text.substr(0, mid);
-  const postfix = `${text.substr(mid)}000`.substr(0, 3);
+  const padding = mid < 0 ? 0 - mid : 0;
+  const postfix = `${`${new Array(padding + 1).join('0')}${text}`.substr(mid < 0 ? 0 : mid)}000`.substr(0, 3);
   const units = withSi
     ? (
       si.value === '-'

--- a/packages/util/src/format/si.ts
+++ b/packages/util/src/format/si.ts
@@ -31,7 +31,8 @@ export const SI: SiDef[] = [
 ];
 
 export function calcSi (text: string, decimals: number): SiDef {
-  return SI[(SI_MID - 1) + Math.ceil((text.length - decimals) / 3)] || SI[SI.length - 1];
+  const siDefIndex = (SI_MID - 1) + Math.ceil((text.length - decimals) / 3);
+  return SI[siDefIndex] || SI[siDefIndex < 0 ? 0 : SI.length - 1];
 }
 
 // Given a SI type (e.g. k, m, Y) find the SI definition


### PR DESCRIPTION
when a number decimals is too high, const mid will be a negative.


```
  it('formats 123,456,789,000 (decimals=36)', (): void => {
    expect(
      formatBalance(TESTVAL, true, 36)
    ).toEqual('0.123y Unit');
  });

```


