### PR TITLE
typescript-eslint 2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,1 +1,12 @@
-module.exports = require('@polkadot/dev/config/eslint');
+const base = require('@polkadot/dev/config/eslint');
+
+module.exports = {
+  ...base,
+  parserOptions: {
+    ...base.parserOptions,
+    extraFileExtensions: ['*.d.ts'],
+    project: [
+      './tsconfig.eslint.json'
+    ]
+  }
+};

--- a/docs/examples/keyring/01_create_account/index.js
+++ b/docs/examples/keyring/01_create_account/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import Keyring class and utility function
 const Keyring = require('@polkadot/keyring').default;

--- a/docs/examples/keyring/02_load_accounts/index.js
+++ b/docs/examples/keyring/02_load_accounts/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import Keyring class and utility function
 const Keyring = require('@polkadot/keyring').default;

--- a/docs/examples/util-crypto/01_encrypt_decrypt_message_nacl/index.js
+++ b/docs/examples/util-crypto/01_encrypt_decrypt_message_nacl/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { naclEncrypt, naclDecrypt } = require('@polkadot/util-crypto');
 

--- a/docs/examples/util-crypto/02_sign_verify_message_nacl/index.js
+++ b/docs/examples/util-crypto/02_sign_verify_message_nacl/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { stringToU8a, u8aToHex } = require('@polkadot/util');
 const { naclEncrypt, naclKeypairFromSeed, naclSign, naclVerify, randomAsU8a } = require('@polkadot/util-crypto');

--- a/docs/examples/util-crypto/03_mnemonic_generate_validate_bip39/index.js
+++ b/docs/examples/util-crypto/03_mnemonic_generate_validate_bip39/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/no-var-requires,@typescript-eslint/no-unused-vars */
 const { mnemonicGenerate, mnemonicToSeed, mnemonicValidate, naclKeypairFromSeed } = require('@polkadot/util-crypto');
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "@polkadot/dev": "^0.31.0-beta.5",
+    "@polkadot/dev": "^0.31.0-beta.6",
     "@polkadot/ts": "^0.1.69",
     "gh-pages": "^2.1.1"
   }

--- a/packages/chainspec/src/alexander.ts
+++ b/packages/chainspec/src/alexander.ts
@@ -4,7 +4,6 @@
 
 import { Chainspec } from './types';
 
-// eslint-disable-next-line @typescript-eslint/no-object-literal-type-assertion
 export default {
   name: 'Alexander',
   id: 'alexander',

--- a/packages/chainspec/src/dried-danta.ts
+++ b/packages/chainspec/src/dried-danta.ts
@@ -4,7 +4,6 @@
 
 import { Chainspec } from './types';
 
-// eslint-disable-next-line @typescript-eslint/no-object-literal-type-assertion
 export default {
   name: 'Dried Danta',
   id: 'dried-danta',

--- a/packages/keyring/src/index.spec.ts
+++ b/packages/keyring/src/index.spec.ts
@@ -19,7 +19,7 @@ describe('keypair', (): void => {
     const seedTwo = hexToU8a('0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60');
     let keypair: Keyring;
 
-    beforeEach(async (): Promise<void> => {
+    beforeEach((): void => {
       keypair = new Keyring({ type: 'ed25519' });
 
       keypair.addFromSeed(seedOne, {});

--- a/packages/keyring/src/keyring.ts
+++ b/packages/keyring/src/keyring.ts
@@ -153,7 +153,7 @@ export default class Keyring implements KeyringInstance {
    */
   public createFromUri (_suri: string, meta: KeyringPair$Meta = {}, type: KeypairType = this.type): KeyringPair {
     // here we only aut-add the dev phrase if we have a hard-derived path
-    const suri = _suri.indexOf('//') === 0
+    const suri = _suri.startsWith('//')
       ? `${DEV_PHRASE}${_suri}`
       : _suri;
     const { password, phrase, path } = keyExtractSuri(suri);

--- a/packages/keyring/src/pairs.ts
+++ b/packages/keyring/src/pairs.ts
@@ -7,10 +7,7 @@ import { KeyringPairs, KeyringPair } from './types';
 import { assert, isHex, isU8a, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';
 
-interface KeyringPairMap {
-  // @ts-ignore we use coercion :(
-  [index: Uint8Array]: KeyringPair;
-}
+type KeyringPairMap = Record<string, KeyringPair>;
 
 export default class Pairs implements KeyringPairs {
   private _map: KeyringPairMap;
@@ -20,8 +17,7 @@ export default class Pairs implements KeyringPairs {
   }
 
   public add (pair: KeyringPair): KeyringPair {
-    // @ts-ignore we use coercion :(
-    this._map[pair.publicKey] = pair;
+    this._map[pair.publicKey.toString()] = pair;
 
     return pair;
   }
@@ -31,8 +27,7 @@ export default class Pairs implements KeyringPairs {
   }
 
   public get (address: string | Uint8Array): KeyringPair {
-    // @ts-ignore we use coercion :(
-    const pair = this._map[decodeAddress(address)];
+    const pair = this._map[decodeAddress(address).toString()];
 
     assert(pair, (): string => {
       const formatted: string = isU8a(address) || isHex(address)
@@ -46,7 +41,6 @@ export default class Pairs implements KeyringPairs {
   }
 
   public remove (address: string | Uint8Array): void {
-    // @ts-ignore we use coercion :(
-    delete this._map[decodeAddress(address)];
+    delete this._map[decodeAddress(address).toString()];
   }
 }

--- a/packages/keyring/src/testing.ts
+++ b/packages/keyring/src/testing.ts
@@ -77,7 +77,7 @@ const PAIRS: PairDef[] = [
  * @description The test accounts (i.e. alice, bob, dave, eve, ferdie)
  * are available on the dev chain and each test account is initialised with DOT funds.
  */
-export default function testKeyring (options: KeyringOptions = {}, isDerived: boolean = true): KeyringInstance {
+export default function testKeyring (options: KeyringOptions = {}, isDerived = true): KeyringInstance {
   const keyring = new Keyring(options);
 
   PAIRS.forEach(({ name, publicKey, secretKey, seed, type }): void => {

--- a/packages/keyring/src/testingPairs.ts
+++ b/packages/keyring/src/testingPairs.ts
@@ -11,7 +11,7 @@ export interface TestKeyringMap {
   [index: string]: KeyringPair;
 }
 
-export default function testKeyringPairs (options?: KeyringOptions, isDerived: boolean = true): TestKeyringMap {
+export default function testKeyringPairs (options?: KeyringOptions, isDerived = true): TestKeyringMap {
   const keyring = createKeyring(options, isDerived);
   const pairs = keyring.getPairs();
   const map: TestKeyringMap = { nobody: nobody() };

--- a/packages/trie-db/src/ethereum.spec.ts
+++ b/packages/trie-db/src/ethereum.spec.ts
@@ -43,9 +43,8 @@ describe.skip('official tests', (): void => {
 
       it(name, (): void => {
         keys.forEach((key: string): void => {
-          // @ts-ignore
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          trie.put(toU8a(key), toU8a(input[key as any]));
+          trie.put(toU8a(key), toU8a(input[key as any] as string));
         });
 
         expect(

--- a/packages/trie-hash/src/buildTrie.ts
+++ b/packages/trie-hash/src/buildTrie.ts
@@ -78,7 +78,7 @@ function _buildTrie (input: [Uint8Array, Uint8Array][], cursor: number, codec: C
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function buildTrie (input: [Uint8Array, Uint8Array][], cursor: number = 0, codec: Codec = DEFAULT_CODEC, stream: any = DEFAULT_STREAM): Uint8Array {
+export default function buildTrie (input: [Uint8Array, Uint8Array][], cursor = 0, codec: Codec = DEFAULT_CODEC, stream: any = DEFAULT_STREAM): Uint8Array {
   const trie = _buildTrie(input, cursor, codec, stream);
 
   return trie;

--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@polkadot/util": "^1.2.0-beta.3",
-    "@polkadot/wasm-crypto": "^0.14.0-beta.1",
+    "@polkadot/wasm-crypto": "^0.14.0-beta.2",
     "@types/bip39": "^2.4.2",
     "@types/bs58": "^4.0.0",
     "@types/pbkdf2": "^3.0.0",

--- a/packages/util-crypto/src/address/decode.spec.ts
+++ b/packages/util-crypto/src/address/decode.spec.ts
@@ -8,7 +8,7 @@ import decode from './decode';
 describe('decode', (): void => {
   let keyring: TestKeyringMap;
 
-  beforeAll(async (): Promise<void> => {
+  beforeAll((): void => {
     keyring = testingPairs({ type: 'sr25519' });
   });
 

--- a/packages/util-crypto/src/blake2/asHex.ts
+++ b/packages/util-crypto/src/blake2/asHex.ts
@@ -20,7 +20,7 @@ import blake2AsU8a from './asU8a';
  * blake2AsHex('abc'); // => 0xba80a53f981c4d0d
  * ```
  */
-export default function blake2AsHex (data: Uint8Array | string, bitLength: number = 256): string {
+export default function blake2AsHex (data: Uint8Array | string, bitLength = 256): string {
   return u8aToHex(
     blake2AsU8a(data, bitLength)
   );

--- a/packages/util-crypto/src/blake2/asU8a.ts
+++ b/packages/util-crypto/src/blake2/asU8a.ts
@@ -20,7 +20,7 @@ import { blake2b, isReady } from '@polkadot/wasm-crypto';
  * blake2AsU8a('abc'); // => [0xba, 0x80, 0xa53, 0xf98, 0x1c, 0x4d, 0x0d]
  * ```
  */
-export default function blake2AsU8a (data: Uint8Array | string, bitLength: number = 256, key: Uint8Array | null = null): Uint8Array {
+export default function blake2AsU8a (data: Uint8Array | string, bitLength = 256, key: Uint8Array | null = null): Uint8Array {
   const byteLength = Math.ceil(bitLength / 8);
 
   return isReady()

--- a/packages/util-crypto/src/key/DeriveJunction.ts
+++ b/packages/util-crypto/src/key/DeriveJunction.ts
@@ -18,10 +18,10 @@ const BN_OPTIONS = {
 export default class DeriveJunction {
   private _chainCode: Uint8Array = new Uint8Array(32);
 
-  private _isHard: boolean = false;
+  private _isHard = false;
 
   public static from (value: string): DeriveJunction {
-    const [code, isHard] = value[0] === '/'
+    const [code, isHard] = value.startsWith('/')
       ? [value.substr(1), true]
       : [value, false];
     const result = new DeriveJunction();

--- a/packages/util-crypto/src/key/extractSuri.ts
+++ b/packages/util-crypto/src/key/extractSuri.ts
@@ -19,6 +19,7 @@ const RE_CAPTURE = /^(\w+( \w+)*)((\/\/?[^/]+)*)(\/\/\/(.*))?$/;
  * @description Extracts the phrase, path and password from a SURI format for specifying secret keys `<secret>/<soft-key>//<hard-key>///<password>` (the `///password` may be omitted, and `/<soft-key>` and `//<hard-key>` maybe repeated and mixed).
  */
 export default function keyExtract (suri: string): ExtractResult {
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
   const matches = suri.match(RE_CAPTURE);
 
   assert(!isNull(matches), `Unable to match '${suri}' to a secret URI`);

--- a/packages/util-crypto/src/mnemonic/toMiniSecret.ts
+++ b/packages/util-crypto/src/mnemonic/toMiniSecret.ts
@@ -10,7 +10,7 @@ import { bip39ToMiniSecret, isReady } from '@polkadot/wasm-crypto';
 
 import toEntropy from './toEntropy';
 
-export default function toMiniSecret (mnemonic: string, password: string = ''): Uint8Array {
+export default function toMiniSecret (mnemonic: string, password = ''): Uint8Array {
   if (isReady()) {
     return bip39ToMiniSecret(mnemonic, password);
   }

--- a/packages/util-crypto/src/mnemonic/toSeed.ts
+++ b/packages/util-crypto/src/mnemonic/toSeed.ts
@@ -23,7 +23,7 @@ import { bip39ToSeed, isReady } from '@polkadot/wasm-crypto';
  * }
  * ```
  */
-export default function toSeed (mnemonic: string, password: string = ''): Uint8Array {
+export default function toSeed (mnemonic: string, password = ''): Uint8Array {
   return isReady()
     ? bip39ToSeed(mnemonic, password)
     : bufferToU8a(mnemonicToSeed(mnemonic, password)).subarray(0, 32);

--- a/packages/util-crypto/src/random/asHex.ts
+++ b/packages/util-crypto/src/random/asHex.ts
@@ -20,7 +20,7 @@ import randomAsU8a from './asU8a';
  * randomAsHex(); // => 0x...
  * ```
  */
-export default function randomAsHex (length: number = 32): string {
+export default function randomAsHex (length = 32): string {
   return u8aToHex(
     randomAsU8a(length)
   );

--- a/packages/util-crypto/src/random/asU8a.ts
+++ b/packages/util-crypto/src/random/asU8a.ts
@@ -18,6 +18,6 @@ import nacl from 'tweetnacl';
  * randomAsU8a(); // => Uint8Array([...])
  * ```
  */
-export default function randomAsU8a (length: number = 32): Uint8Array {
+export default function randomAsU8a (length = 32): Uint8Array {
   return nacl.randomBytes(length);
 }

--- a/packages/util-crypto/src/xxhash/asHex.ts
+++ b/packages/util-crypto/src/xxhash/asHex.ts
@@ -20,7 +20,7 @@ import xxhashAsU8a from './asU8a';
  * xxhashAsHex('abc'); // => 0x44bc2cf5ad770999
  * ```
  */
-export default function xxhashAsHex (data: Buffer | Uint8Array | string, bitLength: number = 64): string {
+export default function xxhashAsHex (data: Buffer | Uint8Array | string, bitLength = 64): string {
   return u8aToHex(
     xxhashAsU8a(data, bitLength)
   );

--- a/packages/util-crypto/src/xxhash/asU8a.ts
+++ b/packages/util-crypto/src/xxhash/asU8a.ts
@@ -21,7 +21,7 @@ import xxhash64AsBn from './xxhash64/asBn';
  * xxhashAsU8a('abc'); // => 0x44bc2cf5ad770999
  * ```
  */
-export default function xxhashAsU8a (data: Buffer | Uint8Array | string, bitLength: number = 64): Uint8Array {
+export default function xxhashAsU8a (data: Buffer | Uint8Array | string, bitLength = 64): Uint8Array {
   const iterations = Math.ceil(bitLength / 64);
 
   if (isReady()) {

--- a/packages/util-crypto/src/xxhash/xxhash64/asValue.ts
+++ b/packages/util-crypto/src/xxhash/xxhash64/asValue.ts
@@ -21,13 +21,11 @@ import { isBuffer, isString, u8aToBuffer } from '@polkadot/util';
  */
 export default function xxhash64AsValue (data: Buffer | Uint8Array | string, seed: number): number {
   if (isBuffer(data) || isString(data)) {
-    // @ts-ignore Buffer is ArrayBuffer underlying
-    return xxhashjs.h64(data, seed);
+    return xxhashjs.h64(data, seed) as unknown as number;
   }
 
-  // @ts-ignore conversion works, yields correct result
   return xxhashjs.h64(
     u8aToBuffer(data),
     seed
-  ) as number;
+  ) as unknown as number;
 }

--- a/packages/util-rlp/src/decoder/decode.ts
+++ b/packages/util-rlp/src/decoder/decode.ts
@@ -30,6 +30,5 @@ export default function decode (input: Uint8Array): DecodeOutput {
 
   assert(decoder, 'Unable to find decoder for input type');
 
-  // @ts-ignore assert catches invalids, which _should_ not happen...
-  return decoder.fn(decode, input);
+  return (decoder as Decoder).fn(decode, input);
 }

--- a/packages/util-rlp/src/encoder/array.ts
+++ b/packages/util-rlp/src/encoder/array.ts
@@ -9,7 +9,7 @@ import { u8aConcat } from '@polkadot/util';
 import encodeLength from './length';
 
 export default function encodeArray (encoder: EncodeFunc, input: (Uint8Array | null)[]): Uint8Array {
-  const encoded = u8aConcat.apply(null, input.map(encoder));
+  const encoded = u8aConcat(...input.map(encoder));
 
   return u8aConcat(
     encodeLength(encoded.length, 192),

--- a/packages/util-rlp/src/encoder/toU8a.ts
+++ b/packages/util-rlp/src/encoder/toU8a.ts
@@ -45,6 +45,5 @@ export default function toU8a (value?: any): Uint8Array {
 
   assert(encoder, 'invalid type');
 
-  // @ts-ignore the assert catches any unknowns
-  return encoder.fn(value);
+  return (encoder as Encoder).fn(value);
 }

--- a/packages/util-rlp/test/getTests.ts
+++ b/packages/util-rlp/test/getTests.ts
@@ -19,9 +19,9 @@ export default function getTests (file: string): Test[] {
 
   return Object.keys(tests).map((name): Test => ({
     name,
-    input: tests[name].in[0] !== '#'
-      ? tests[name].in
-      : bnToU8a(new BN(tests[name].in.slice(1)), { isLe: false }),
+    input: tests[name].in.startsWith('#')
+      ? bnToU8a(new BN(tests[name].in.slice(1)), { isLe: false })
+      : tests[name].in,
     output: tests[name].out
       ? `0x${tests[name].out.toLowerCase()}`
       : undefined,

--- a/packages/util-rlp/test/getTests.ts
+++ b/packages/util-rlp/test/getTests.ts
@@ -19,7 +19,8 @@ export default function getTests (file: string): Test[] {
 
   return Object.keys(tests).map((name): Test => ({
     name,
-    input: tests[name].in.startsWith('#')
+    // eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
+    input: tests[name].in[0] === '#'
       ? bnToU8a(new BN(tests[name].in.slice(1)), { isLe: false })
       : tests[name].in,
     output: tests[name].out

--- a/packages/util/src/array/filter.ts
+++ b/packages/util/src/array/filter.ts
@@ -21,7 +21,7 @@ import isUndefined from '../is/undefined';
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function arrayFilter (array: any[], allowNulls: boolean = true): any[] {
+export default function arrayFilter (array: any[], allowNulls = true): any[] {
   return array.filter((value): boolean => {
     return !isUndefined(value) && (allowNulls || !isNull(value));
   });

--- a/packages/util/src/bn/toBn.ts
+++ b/packages/util/src/bn/toBn.ts
@@ -37,5 +37,5 @@ export default function bnToBn <ExtToBn extends ToBn> (value?: ExtToBn | BN | st
     ? value
     : isToBn(value)
       ? value.toBn()
-      : new BN(value as number);
+      : new BN(value);
 }

--- a/packages/util/src/ext/error.spec.ts
+++ b/packages/util/src/ext/error.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.

--- a/packages/util/src/ext/error.ts
+++ b/packages/util/src/ext/error.ts
@@ -31,28 +31,32 @@ function extend (that: ExtError, name: string, value?: string | number): void {
  * ```
  */
 export default class ExtError extends Error implements ExtErrorInterface {
-  // @ts-ignore we are assigning it via extend
   public code: number;
 
   public data?: number | string;
 
-  // @ts-ignore we are assigning it via extend
   public message: string;
-  // @ts-ignore we are assigning it via extend
 
   public name: string;
 
-  // @ts-ignore we are assigning it via extend
   public stack: string;
 
-  public constructor (message: string = '', code: number = UNKNOWN, data?: number | string) {
+  public constructor (message = '', code: number = UNKNOWN, data?: number | string) {
     super();
+
+    // These are actually done via extend below to clean them up
+    this.code = code;
+    this.data = data;
+    this.name = name;
+    this.message = message;
+    this.stack = '';
 
     extend(this, 'message', String(message));
     extend(this, 'name', this.constructor.name);
     extend(this, 'data', data);
     extend(this, 'code', code);
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     if (isFunction(Error.captureStackTrace)) {
       Error.captureStackTrace(this, this.constructor);
     } else {

--- a/packages/util/src/format/formatBalance.ts
+++ b/packages/util/src/format/formatBalance.ts
@@ -32,7 +32,7 @@ let defaultDecimals = DEFAULT_DECIMALS;
 let defaultUnit = DEFAULT_UNIT;
 
 // Formats a string/number with <prefix>.<postfix><type> notation
-function _formatBalance <ExtToBn extends ToBn> (input?: number | string | BN | ExtToBn, withSi: boolean = true, decimals: number = defaultDecimals): string {
+function _formatBalance <ExtToBn extends ToBn> (input?: number | string | BN | ExtToBn, withSi = true, decimals: number = defaultDecimals): string {
   let text = bnToBn(input).toString();
 
   if (text.length === 0 || text === '0') {
@@ -41,7 +41,7 @@ function _formatBalance <ExtToBn extends ToBn> (input?: number | string | BN | E
 
   // strip the negative sign so we can work with clean groupings, re-add this in the
   // end when we return the result (from here on we work with positive numbers)
-  const isNegative = text[0] === '-';
+  const isNegative = text[0].startsWith('-');
 
   if (isNegative) {
     text = text.substr(1);
@@ -68,10 +68,14 @@ function _formatBalance <ExtToBn extends ToBn> (input?: number | string | BN | E
 
 const formatBalance = _formatBalance as BalanceFormatter;
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
 formatBalance.calcSi = (text: string, decimals: number = defaultDecimals): SiDef =>
   calcSi(text, decimals);
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
 formatBalance.findSi = findSi;
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
 formatBalance.getDefaults = (): Defaults => {
   return {
     decimals: defaultDecimals,
@@ -80,6 +84,7 @@ formatBalance.getDefaults = (): Defaults => {
 };
 
 // get allowable options to display in a dropdown
+// eslint-disable-next-line @typescript-eslint/unbound-method
 formatBalance.getOptions = (decimals: number = defaultDecimals): SiDef[] => {
   return SI.filter(({ power }): boolean =>
     power < 0
@@ -89,6 +94,7 @@ formatBalance.getOptions = (decimals: number = defaultDecimals): SiDef[] => {
 };
 
 // Sets the default decimals to use for formatting (ui-wide)
+// eslint-disable-next-line @typescript-eslint/unbound-method
 formatBalance.setDefaults = ({ decimals, unit }: Partial<Defaults>): void => {
   defaultDecimals = isUndefined(decimals) ? defaultDecimals : decimals;
   defaultUnit = isUndefined(unit) ? defaultUnit : unit;

--- a/packages/util/src/format/formatDecimal.ts
+++ b/packages/util/src/format/formatDecimal.ts
@@ -7,7 +7,7 @@ const NUMBER_REGEX = new RegExp('(\\d+?)(?=(\\d{3})+(?!\\d)|$)', 'g');
 export default function formatDecimal (value: string): string {
   // We can do this by adjusting the regx, however for the sake of clarity
   // we rather strip and re-add the negative sign in the output
-  const isNegative = value[0] === '-';
+  const isNegative = value[0].startsWith('-');
   const matched = isNegative
     ? value.substr(1).match(NUMBER_REGEX)
     : value.match(NUMBER_REGEX);

--- a/packages/util/src/hex/fixLength.ts
+++ b/packages/util/src/hex/fixLength.ts
@@ -21,7 +21,7 @@ import hexStripPrefix from './stripPrefix';
  * console.log('fixed', hexFixLength('0x0012', 8)); // => 0x12
  * ```
  */
-export default function hexFixLength (value: string, bitLength: number = -1, withPadding: boolean = false): string {
+export default function hexFixLength (value: string, bitLength = -1, withPadding = false): string {
   const strLength = Math.ceil(bitLength / 4);
   const hexLength = strLength + 2;
 

--- a/packages/util/src/hex/toU8a.ts
+++ b/packages/util/src/hex/toU8a.ts
@@ -21,7 +21,7 @@ import hexStripPrefix from './stripPrefix';
  * hexToU8a('0x80001f', 32); // Uint8Array([0x00, 0x80, 0x00, 0x1f])
  * ```
  */
-export default function hexToU8a (_value?: string | null, bitLength: number = -1): Uint8Array {
+export default function hexToU8a (_value?: string | null, bitLength = -1): Uint8Array {
   if (!_value) {
     return new Uint8Array([]);
   }

--- a/packages/util/src/is/hex.ts
+++ b/packages/util/src/is/hex.ts
@@ -22,7 +22,7 @@ const HEX_REGEX = /^0x[a-fA-F0-9]+$/;
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/ban-types
-export default function isHex (value: any, bitLength: number = -1, ignoreLength: boolean = false): value is string | String {
+export default function isHex (value: any, bitLength = -1, ignoreLength = false): value is string | String {
   const isValidHex = value === '0x' || (isString(value) && HEX_REGEX.test(value.toString()));
 
   if (isValidHex && bitLength !== -1) {

--- a/packages/util/src/is/ip.ts
+++ b/packages/util/src/is/ip.ts
@@ -24,12 +24,9 @@ type IpTypes = 'v4' | 'v6';
  * ```
  */
 export default function isIp (value: string, type?: IpTypes): boolean {
-  // FIXME @types/ip-regex defintions are outdated
   if (type === 'v4') {
-    // @ts-ignore
     return ipRegex.v4({ exact: true }).test(value);
   } else if (type === 'v6') {
-    // @ts-ignore
     return ipRegex.v6({ exact: true }).test(value);
   }
 

--- a/packages/util/src/logger.ts
+++ b/packages/util/src/logger.ts
@@ -80,13 +80,10 @@ function apply (log: LogType, type: string, values: Logger$Data): void {
   const chalk = (value: string): string =>
     chalked[log](value);
 
-  // @ts-ignore Not sure how to coax TS here...
-  console[logTo[log]].apply(
-    console, [
-      chalk(moment().format('YYYY-MM-DD HH:mm:ss')), chalk(type)
-    ].concat(
-      values.map(format)
-    )
+  console[logTo[log] as 'log'](
+    chalk(moment().format('YYYY-MM-DD HH:mm:ss')),
+    chalk(type),
+    ...values.map(format)
   );
 }
 
@@ -117,7 +114,7 @@ export default function logger (_type: string): Logger {
     const isTest = process.env.NODE_ENV === 'test';
     const debugList = (process.env.DEBUG || '').split(',');
 
-    isDebug = isTest || !!debugList.find((entry): boolean => _type.indexOf(entry) === 0);
+    isDebug = isTest || !!debugList.find((entry): boolean => _type.startsWith(entry));
   } catch (error) {
     isDebug = false;
   }

--- a/packages/util/src/number/toHex.ts
+++ b/packages/util/src/number/toHex.ts
@@ -21,7 +21,7 @@ import isUndefined from '../is/undefined';
  * numberToHex(0x1234, 32); // => 0x00001234
  * ```
  */
-export default function numberToHex (value?: number | null, bitLength: number = -1): string {
+export default function numberToHex (value?: number | null, bitLength = -1): string {
   if (isUndefined(value) || isNull(value) || isNaN(value)) {
     return '0x';
   }

--- a/packages/util/src/number/toU8a.ts
+++ b/packages/util/src/number/toU8a.ts
@@ -19,7 +19,7 @@ import numberToHex from './toHex';
  * numberToU8a(0x1234); // => [0x12, 0x34]
  * ```
  */
-export default function numberToU8a (value?: number | null, bitLength: number = -1): Uint8Array {
+export default function numberToU8a (value?: number | null, bitLength = -1): Uint8Array {
   if (!value || isNaN(value)) {
     return new Uint8Array([]);
   }

--- a/packages/util/src/polyfill/fill.spec.ts
+++ b/packages/util/src/polyfill/fill.spec.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+/* eslint-disable no-extend-native */
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
@@ -12,19 +15,15 @@ describe('Array.fill', (): void => {
     u8aFill = Uint8Array.prototype.fill;
 
     // @ts-ignore
-    // eslint-disable-next-line no-extend-native
     Array.prototype.fill = null;
     // @ts-ignore
-    // eslint-disable-next-line no-extend-native
     Uint8Array.prototype.fill = null;
 
     require('./fill');
   });
 
   afterEach((): void => {
-    // eslint-disable-next-line no-extend-native
     Array.prototype.fill = arrayFill;
-    // eslint-disable-next-line no-extend-native
     Uint8Array.prototype.fill = u8aFill;
   });
 

--- a/packages/util/src/polyfill/fill.ts
+++ b/packages/util/src/polyfill/fill.ts
@@ -1,10 +1,12 @@
+/* eslint-disable no-extend-native */
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 if (!Array.prototype.fill) {
   // eslint-disable-next-line no-extend-native,@typescript-eslint/no-explicit-any
-  Array.prototype.fill = function fill (value: any, start: number = 0, end?: number): any[] {
+  Array.prototype.fill = function fill (value: any, start = 0, end?: number): any[] {
     // Steps 1-2.
     if (!this) {
       throw new TypeError('this is null or not defined');
@@ -45,7 +47,7 @@ if (!Array.prototype.fill) {
 }
 
 if (!Uint8Array.prototype.fill) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
-  // eslint-disable-next-line no-extend-native
   Uint8Array.prototype.fill = Array.prototype.fill;
 }

--- a/packages/util/src/polyfill/padEnd.spec.ts
+++ b/packages/util/src/polyfill/padEnd.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.

--- a/packages/util/src/polyfill/padEnd.ts
+++ b/packages/util/src/polyfill/padEnd.ts
@@ -1,10 +1,11 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 if (!String.prototype.padEnd) {
   // eslint-disable-next-line no-extend-native
-  String.prototype.padEnd = function padEnd (length: number, char: string = ' '): string {
+  String.prototype.padEnd = function padEnd (length: number, char = ' '): string {
     let result = String(this);
 
     while (result.length < length) {

--- a/packages/util/src/polyfill/padEnd.ts
+++ b/packages/util/src/polyfill/padEnd.ts
@@ -1,10 +1,10 @@
+/* eslint-disable no-extend-native */
 /* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 if (!String.prototype.padEnd) {
-  // eslint-disable-next-line no-extend-native
   String.prototype.padEnd = function padEnd (length: number, char = ' '): string {
     let result = String(this);
 

--- a/packages/util/src/polyfill/padStart.spec.ts
+++ b/packages/util/src/polyfill/padStart.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.

--- a/packages/util/src/polyfill/padStart.ts
+++ b/packages/util/src/polyfill/padStart.ts
@@ -1,10 +1,11 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 if (!String.prototype.padStart) {
   // eslint-disable-next-line no-extend-native
-  String.prototype.padStart = function padStart (length: number, char: string = ' '): string {
+  String.prototype.padStart = function padStart (length: number, char = ' '): string {
     let result = String(this);
 
     while (result.length < length) {

--- a/packages/util/src/polyfill/padStart.ts
+++ b/packages/util/src/polyfill/padStart.ts
@@ -1,10 +1,10 @@
+/* eslint-disable no-extend-native */
 /* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 if (!String.prototype.padStart) {
-  // eslint-disable-next-line no-extend-native
   String.prototype.padStart = function padStart (length: number, char = ' '): string {
     let result = String(this);
 

--- a/packages/util/src/polyfill/setPrototypeOf.spec.ts
+++ b/packages/util/src/polyfill/setPrototypeOf.spec.ts
@@ -1,3 +1,6 @@
+/* eslint-disable no-proto */
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
@@ -23,7 +26,6 @@ describe('setPrototypeOf', (): void => {
     const obj = {};
     const proto = { foo: 'bar' };
 
-    // eslint-disable-next-line no-proto
     expect(Object.setPrototypeOf(obj, proto).__proto__).toBe(proto);
   });
 });

--- a/packages/util/src/polyfill/setPrototypeOf.ts
+++ b/packages/util/src/polyfill/setPrototypeOf.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.

--- a/packages/util/src/polyfill/textDecoder.spec.ts
+++ b/packages/util/src/polyfill/textDecoder.spec.ts
@@ -19,6 +19,7 @@ describe('TextDecoder', (): void => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).TextDecoder = null;
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     expect(require('./textDecoder')).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((global as any).TextDecoder).toBeDefined();
@@ -28,6 +29,7 @@ describe('TextDecoder', (): void => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).TextDecoder = require('util').TextDecoder;
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     expect(require('./textDecoder')).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((global as any).TextDecoder).toBeDefined();

--- a/packages/util/src/polyfill/textDecoder.ts
+++ b/packages/util/src/polyfill/textDecoder.ts
@@ -1,11 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // Copyright 2017-2019 @polkadot/util authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 if (typeof TextDecoder === 'undefined') {
   try {
-    // @ts-ignore
-    global.TextDecoder = require('util').TextDecoder;
+    (global as any).TextDecoder = require('util').TextDecoder;
   } catch (error) {
     // noop
   }

--- a/packages/util/src/polyfill/textEncoder.spec.ts
+++ b/packages/util/src/polyfill/textEncoder.spec.ts
@@ -19,6 +19,7 @@ describe('TextEncoder', (): void => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).TextEncoder = null;
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     expect(require('./textEncoder')).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((global as any).TextEncoder).toBeDefined();
@@ -28,6 +29,7 @@ describe('TextEncoder', (): void => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).TextEncoder = require('util').TextEncoder;
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     expect(require('./textEncoder')).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((global as any).TextEncoder).toBeDefined();

--- a/packages/util/src/polyfill/textEncoder.ts
+++ b/packages/util/src/polyfill/textEncoder.ts
@@ -4,8 +4,8 @@
 
 if (typeof TextEncoder === 'undefined') {
   try {
-    // @ts-ignore For the Node.js case
-    global.TextEncoder = require('util').TextEncoder;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).TextEncoder = require('util').TextEncoder;
   } catch (error) {
     // noop
   }

--- a/packages/util/src/promisify.spec.ts
+++ b/packages/util/src/promisify.spec.ts
@@ -31,7 +31,6 @@ describe('promisify', (): void => {
     const fn = (a: number, b: boolean, cb: (error: Error | null, result?: [number, boolean]) => void): void =>
       cb(null, [a, b]);
 
-    // @ts-ignore
     return promisify(null, fn, 2, false).then((result: [number, boolean]): void => {
       expect(result).toEqual([2, false]);
     });
@@ -41,19 +40,8 @@ describe('promisify', (): void => {
     const fn = (a: number, b: boolean, c: string, cb: (error: Error | null, result?: [number, boolean, string]) => void): void =>
       cb(new Error(`test reject: ${a},${b},${c}`));
 
-    // @ts-ignore
     return promisify(null, fn, 3, 'string', true).catch((error: Error): void => {
       expect(error.message).toEqual('test reject: 3,string,true');
-    });
-  });
-
-  it('applies the correct this argument', (): Promise<void> => {
-    const self = { something: 'something' };
-
-    return promisify(self, function (cb: (error: Error | null) => void): void {
-      // @ts-ignore
-      expect(this).toEqual(self);
-      cb(null);
     });
   });
 });

--- a/packages/util/src/promisify.ts
+++ b/packages/util/src/promisify.ts
@@ -4,19 +4,6 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-// this is horrible, but we want it typed, so... 6 params should be enough for everybody?
-export interface PromisifyFn {
-  (cb: (error: Error | null, result?: any) => any): any;
-  (a: any, cb: (error: Error | null, result?: any) => any): any;
-  (a: any, b: any, cb: (error: Error | null, result?: any) => any): any;
-  (a: any, b: any, c: any, cb: (error: Error | null, result?: any) => any): any;
-  (a: any, b: any, c: any, d: any, cb: (error: Error | null, result?: any) => any): any;
-  (a: any, b: any, c: any, d: any, e: any, cb: (error: Error | null, result?: any) => any): any;
-  (a: any, b: any, c: any, d: any, e: any, f: any, cb: (error: Error | null, result?: any) => any): any;
-}
-
-type ParamType = [] | [any] | [any, any] | [any, any, any]| [any, any, any, any]| [any, any, any, any, any]| [any, any, any, any, any, any];
-
 /**
  * @name promisify
  * @summary Wraps an async callback into a `Promise`
@@ -32,17 +19,16 @@ type ParamType = [] | [any] | [any, any] | [any, any, any]| [any, any, any, any]
  * await promisify(null, (cb) => cb(new Error('error!'))); // rejects with `error!`
  * ```
  */
-export default function promisify (self: any, fn: PromisifyFn, ...params: ParamType): Promise<any> {
+export default function promisify (self: any, fn: Function, ...params: any[]): Promise<any> {
   return new Promise((resolve, reject): void => {
-    fn.apply(self, params.concat([
-      // @ts-ignore
-      (error: Error | null, result?: any): void => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(result);
-        }
+    const handler = (error: Error | null, result?: any): void => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
       }
-    ]));
+    };
+
+    fn.apply(self, [...params, handler]);
   });
 }

--- a/packages/util/src/string/shorten.ts
+++ b/packages/util/src/string/shorten.ts
@@ -17,7 +17,7 @@
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function stringShorten (_value?: any, prefixLength: number = 6): string {
+export default function stringShorten (_value?: any, prefixLength = 6): string {
   const value = `${_value}`;
 
   if (value.length <= 2 + 2 * prefixLength) {

--- a/packages/util/src/u8a/fixLength.ts
+++ b/packages/util/src/u8a/fixLength.ts
@@ -18,7 +18,7 @@
  * u8aFixLength('0x1234', 8) // => 0x12
  * ```
  */
-export default function u8aFixLength (value: Uint8Array, bitLength: number = -1, atStart: boolean = false): Uint8Array {
+export default function u8aFixLength (value: Uint8Array, bitLength = -1, atStart = false): Uint8Array {
   const byteLength = Math.ceil(bitLength / 8);
 
   if (bitLength === -1 || value.length === byteLength) {

--- a/packages/util/src/u8a/toBuffer.ts
+++ b/packages/util/src/u8a/toBuffer.ts
@@ -21,6 +21,5 @@ export default function u8aToBuffer (value?: Uint8Array | null): Buffer {
     return Buffer.from([]);
   }
 
-  // @ts-ignore yes, from also works with u8a
   return Buffer.from(value);
 }

--- a/packages/util/src/u8a/toHex.ts
+++ b/packages/util/src/u8a/toHex.ts
@@ -18,7 +18,7 @@ const ALPHABET = '0123456789abcdef';
  * u8aToHex(new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0xf])); // 0x68656c0f
  * ```
  */
-export default function u8aToHex (value?: Uint8Array | null, bitLength: number = -1, isPrefixed: boolean = true): string {
+export default function u8aToHex (value?: Uint8Array | null, bitLength = -1, isPrefixed = true): string {
   const prefix = isPrefixed
     ? '0x'
     : '';

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "packages/**/*.d.ts",
+    "packages/**/*.ts",
+    "packages/**/*.tsx",
+    "packages/**/*.js",
+    "packages/**/*.spec.ts",
+    "packages/**/*.spec.js",
+    "*.js"
+  ],
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,9 +1845,9 @@
     vuepress "^1.0.3"
 
 "@polkadot/ts@^0.1.69":
-  version "0.1.69"
-  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.69.tgz#ffc5b4b4c7aedc0a7e61d13b9487ba3bae30cbd5"
-  integrity sha512-JrzntjqVfEOV/VEMNx8TeW4263bLyvou+ecxNUAW1plAQXEp7PdDtR1wVS1mlhM0/mXt1iYZXet2XchP0po7Fg==
+  version "0.1.70"
+  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.70.tgz#0f6462871c557fc81bf0e0542d5ac4ccd18f134c"
+  integrity sha512-SREHjU1WHfQeHo8/ieeQuiahHXSvZMyySdP44+G+sySgTDHK5wfOK7zJKv1dFOZBHrWcqtjCptTNMg2B9E2ysQ==
   dependencies:
     "@types/chrome" "^0.0.88"
 
@@ -1998,9 +1998,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*", "@types/node@^12.7.2":
-  version "12.7.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
-  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
+  version "12.7.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.3.tgz#27b3f40addaf2f580459fdb405222685542f907a"
+  integrity sha512-3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ==
 
 "@types/pbkdf2@^3.0.0":
   version "3.0.0"
@@ -4760,9 +4760,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.191:
-  version "1.3.244"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.244.tgz#7ba5461fa320ab16540a31b1d0defb7ec29b16e4"
-  integrity sha512-nEfPd2EKnFeLuZ/+JsRG3KixRQwWf2SPpp09ftNt5ouGhg408N759+oXvdXy57+TcM34ykfJYj2JMkc1O3R0lQ==
+  version "1.3.245"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.245.tgz#1829c45165853c37f74e9f6736546917f78a03d4"
+  integrity sha512-W1Tjm8VhabzYmiqLUD/sT/KTKkvZ8QpSkbTfLELBrFdnrolfkCgcbxFE3NXAxL5xedWXF74wWn0j6oVrgBdemw==
 
 elliptic@^6.0.0, elliptic@^6.4.1:
   version "6.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,10 +1799,10 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@polkadot/dev@^0.31.0-beta.5":
-  version "0.31.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.31.0-beta.5.tgz#8e854d1b4bc876253916c91b141de3be6d19e667"
-  integrity sha512-INo4EzxYJTVzGoPE1FJPR8oc9/Fa7/0t33kipXh7+D0J+qXN5bXylaHUAoi0+edrPzZeeErW+n6i2V8/LDNTPg==
+"@polkadot/dev@^0.31.0-beta.6":
+  version "0.31.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.31.0-beta.6.tgz#b2e760bec71fe831a377c9c7cf33a05174476cc8"
+  integrity sha512-+fV1MHWincNHAdUDeLt+PfEwWNceXR85nMjisIAnWcpzr882+dc+mC/8/rQF3LvSJZQvOUMP7ZxrEP8kX8O68Q==
   dependencies:
     "@babel/cli" "^7.5.5"
     "@babel/core" "^7.5.5"
@@ -1817,8 +1817,8 @@
     "@babel/runtime" "^7.5.5"
     "@types/jest" "^24.0.18"
     "@types/node" "^12.7.2"
-    "@typescript-eslint/eslint-plugin" "^1.13.0"
-    "@typescript-eslint/parser" "^1.13.0"
+    "@typescript-eslint/eslint-plugin" "^2.0.0"
+    "@typescript-eslint/parser" "^2.0.0"
     babel-core "^7.0.0-bridge.0"
     babel-jest "^24.9.0"
     babel-plugin-module-resolver "^3.2.0"
@@ -1851,10 +1851,10 @@
   dependencies:
     "@types/chrome" "^0.0.88"
 
-"@polkadot/wasm-crypto@^0.14.0-beta.1":
-  version "0.14.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-0.14.0-beta.1.tgz#a4dcd96925444f90649344907600a92ba6b78acc"
-  integrity sha512-tIZ5UWi/tAKw3/1SkOrBmdqmsuaz+iMNv/QzRQO2A1BkmlYTDTrNOWhQ/0myVHaPoNb+h0f/L4+2tGheX4h+1w==
+"@polkadot/wasm-crypto@^0.14.0-beta.2":
+  version "0.14.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-0.14.0-beta.2.tgz#a405cbf019e0213b6d6df7ad0062fc766af3f537"
+  integrity sha512-QGXgLfeaQDKBASZ70mrSApQ8ROOj2eRDdSUSNu+ApgoRODptkm7NrRtGBWw+5nH5qVOmGG3eZYFHFDZGUrlOag==
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"
@@ -2045,43 +2045,43 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz#22fed9b16ddfeb402fd7bcde56307820f6ebc49f"
-  integrity sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==
+"@typescript-eslint/eslint-plugin@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.0.0.tgz#609a5d7b00ce21a6f94d7ef282eba9da57ca1e42"
+  integrity sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "1.13.0"
-    eslint-utils "^1.3.1"
+    "@typescript-eslint/experimental-utils" "2.0.0"
+    eslint-utils "^1.4.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
-    tsutils "^3.7.0"
+    tsutils "^3.14.0"
 
-"@typescript-eslint/experimental-utils@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
-  integrity sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==
+"@typescript-eslint/experimental-utils@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.0.0.tgz#f3d298bb411357f35c4184e24280b256b6321949"
+  integrity sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "1.13.0"
+    "@typescript-eslint/typescript-estree" "2.0.0"
     eslint-scope "^4.0.0"
 
-"@typescript-eslint/parser@^1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.13.0.tgz#61ac7811ea52791c47dc9fd4dd4a184fae9ac355"
-  integrity sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==
+"@typescript-eslint/parser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.0.0.tgz#4273bb19d03489daf8372cdaccbc8042e098178f"
+  integrity sha512-ibyMBMr0383ZKserIsp67+WnNVoM402HKkxqXGlxEZsXtnGGurbnY90pBO3e0nBUM7chEEOcxUhgw9aPq7fEBA==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "1.13.0"
-    "@typescript-eslint/typescript-estree" "1.13.0"
+    "@typescript-eslint/experimental-utils" "2.0.0"
+    "@typescript-eslint/typescript-estree" "2.0.0"
     eslint-visitor-keys "^1.0.0"
 
-"@typescript-eslint/typescript-estree@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
-  integrity sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==
+"@typescript-eslint/typescript-estree@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.0.0.tgz#c9f6c0efd1b11475540d6a55dc973cc5b9a67e77"
+  integrity sha512-NXbmzA3vWrSgavymlzMWNecgNOuiMMp62MO3kI7awZRLRcsA1QrYWo6q08m++uuAGVbXH/prZi2y1AWuhSu63w==
   dependencies:
     lodash.unescape "4.0.1"
-    semver "5.5.0"
+    semver "^6.2.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
@@ -5011,7 +5011,7 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1, eslint-utils@^1.4.2:
+eslint-utils@^1.4.0, eslint-utils@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
   integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
@@ -10365,11 +10365,6 @@ selfsigned@^1.10.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
-
 semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
@@ -11333,7 +11328,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tsutils@^3.7.0:
+tsutils@^3.14.0:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==


### PR DESCRIPTION
... as a bonus, this actually gets rid of the `@ts-ignore` overrides in the code as well... since eslint actually warns about these as well now, and you don't want to override the override with an override...