### PR TITLE
Rename keyring constructor parameter type -> defaultType

### DIFF
--- a/packages/keyring/src/index.spec.ts
+++ b/packages/keyring/src/index.spec.ts
@@ -20,7 +20,7 @@ describe('keypair', (): void => {
     let keypair: Keyring;
 
     beforeEach((): void => {
-      keypair = new Keyring({ type: 'ed25519' });
+      keypair = new Keyring({ defaultType: 'ed25519' });
 
       keypair.addFromSeed(seedOne, {});
     });
@@ -88,7 +88,7 @@ describe('keypair', (): void => {
     let keypair: Keyring;
 
     beforeEach((): void => {
-      keypair = new Keyring({ type: 'sr25519' });
+      keypair = new Keyring({ defaultType: 'sr25519' });
 
       keypair.addFromSeed(seedOne, {});
     });

--- a/packages/keyring/src/keyring.ts
+++ b/packages/keyring/src/keyring.ts
@@ -87,7 +87,7 @@ export default class Keyring implements KeyringInstance {
    * of an account backup), and then generates a keyring pair from them that it passes to
    * `addPair` to stores in a keyring pair dictionary the public key of the generated pair as a key and the pair as the associated value.
    */
-  public addFromAddress (address: string | Uint8Array, meta: KeyringPair$Meta = {}, encoded: Uint8Array | null = null, type: KeypairType = this.type, ignoreChecksum?: boolean): KeyringPair {
+  public addFromAddress (address: string | Uint8Array, meta: KeyringPair$Meta = {}, encoded: Uint8Array | null = null, type: KeypairType = this.defaultType, ignoreChecksum?: boolean): KeyringPair {
     const publicKey = this.decodeAddress(address, ignoreChecksum);
 
     return this.addPair(createPair(type, { publicKey, secretKey: new Uint8Array(64) }, meta, encoded));

--- a/packages/keyring/src/pair/decode.spec.ts
+++ b/packages/keyring/src/pair/decode.spec.ts
@@ -4,7 +4,7 @@
 
 import testingPairs from '../testingPairs';
 
-const keyring = testingPairs({ type: 'ed25519' }, false);
+const keyring = testingPairs({ defaultType: 'ed25519' }, false);
 
 describe('decode', (): void => {
   it('fails when no data provided', (): void => {

--- a/packages/keyring/src/pair/encode.spec.ts
+++ b/packages/keyring/src/pair/encode.spec.ts
@@ -8,7 +8,7 @@ import { PKCS8_DIVIDER, PKCS8_HEADER, PUB_LENGTH, SEC_LENGTH } from './defaults'
 const PKCS8_LENGTH = PKCS8_DIVIDER.length + PKCS8_HEADER.length + PUB_LENGTH + SEC_LENGTH;
 const ENCODED_LENGTH = 157;
 
-const keyring = testingPairs({ type: 'ed25519' }, false);
+const keyring = testingPairs({ defaultType: 'ed25519' }, false);
 
 describe('encode', (): void => {
   it('returns PKCS8 when no passphrase supplied', (): void => {

--- a/packages/keyring/src/pair/index.spec.ts
+++ b/packages/keyring/src/pair/index.spec.ts
@@ -7,7 +7,7 @@ import { setAddressPrefix } from '@polkadot/util-crypto';
 import testingPairs from '../testingPairs';
 import createPair from '.';
 
-const keyring = testingPairs({ type: 'ed25519' }, false);
+const keyring = testingPairs({ defaultType: 'ed25519' }, false);
 
 describe('pair', (): void => {
   const SIGNATURE = new Uint8Array([80, 191, 198, 147, 225, 207, 75, 88, 126, 39, 129, 109, 191, 38, 72, 181, 75, 254, 81, 143, 244, 79, 237, 38, 236, 141, 28, 252, 134, 26, 169, 234, 79, 33, 153, 158, 151, 34, 175, 188, 235, 20, 35, 135, 83, 120, 139, 211, 233, 130, 1, 208, 201, 215, 73, 80, 56, 98, 185, 196, 11, 8, 193, 14]);

--- a/packages/keyring/src/pair/toJson.spec.ts
+++ b/packages/keyring/src/pair/toJson.spec.ts
@@ -4,7 +4,7 @@
 
 import testingPairs from '../testingPairs';
 
-const keyring = testingPairs({ type: 'ed25519' }, false);
+const keyring = testingPairs({ defaultType: 'ed25519' }, false);
 
 describe('toJson', (): void => {
   it('creates an unencoded output with no passphrase', (): void => {

--- a/packages/keyring/src/suri.spec.ts
+++ b/packages/keyring/src/suri.spec.ts
@@ -60,7 +60,7 @@ const TESTS = [
 ];
 
 describe('keyring.addFromUri', (): void => {
-  const keyring = new Keyring({ type: 'sr25519' });
+  const keyring = new Keyring({ defaultType: 'sr25519' });
 
   beforeEach(async (): Promise<void> => {
     await cryptoWaitReady();

--- a/packages/keyring/src/testing.ts
+++ b/packages/keyring/src/testing.ts
@@ -87,7 +87,7 @@ export default function testKeyring (options: KeyringOptions = {}, isDerived = t
     };
 
     const pair = !isDerived && !name
-      ? keyring.addFromUri(seed, meta, options.type)
+      ? keyring.addFromUri(seed, meta, options.defaultType)
       : keyring.addPair(
         createPair(type || 'sr25519', { publicKey, secretKey }, meta)
       );

--- a/packages/keyring/src/testingPairs.spec.ts
+++ b/packages/keyring/src/testingPairs.spec.ts
@@ -19,19 +19,19 @@ describe('testingPairs', (): void => {
 
   it('has the correct address for Alice (non-HDKD)', (): void => {
     expect(
-      testingPairs({ type: 'ed25519' }, false).alice.address
+      testingPairs({ defaultType: 'ed25519' }, false).alice.address
     ).toEqual('5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaQua');
   });
 
   it('has the correct address for Alice (HDKD)', (): void => {
     expect(
-      testingPairs({ type: 'ed25519' }).alice.address
+      testingPairs({ defaultType: 'ed25519' }).alice.address
     ).toEqual('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY');
   });
 
   it('has the correct address for Alice_session (HDKD)', (): void => {
     expect(
-      testingPairs({ type: 'ed25519' }).alice_session.address
+      testingPairs({ defaultType: 'ed25519' }).alice_session.address
     ).toEqual('5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu');
   });
 });

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -8,7 +8,7 @@ import { KeypairType } from '@polkadot/util-crypto/types';
 
 export interface KeyringOptions {
   addressPrefix?: Prefix;
-  type?: KeypairType;
+  defaultType?: KeypairType;
 }
 
 export interface KeyringPair$Meta {

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -57,7 +57,7 @@ export interface KeyringPairs {
 export interface KeyringInstance {
   readonly pairs: KeyringPair[];
   readonly publicKeys: Uint8Array[];
-  readonly type: KeypairType;
+  readonly defaultType: KeypairType;
 
   decodeAddress (encoded: string | Uint8Array, ignoreChecksum?: boolean): Uint8Array;
   encodeAddress (key: Uint8Array | string): string;

--- a/packages/util-crypto/src/address/decode.spec.ts
+++ b/packages/util-crypto/src/address/decode.spec.ts
@@ -9,7 +9,7 @@ describe('decode', (): void => {
   let keyring: TestKeyringMap;
 
   beforeAll((): void => {
-    keyring = testingPairs({ type: 'sr25519' });
+    keyring = testingPairs({ defaultType: 'sr25519' });
   });
 
   it('decodes an address', (): void => {

--- a/packages/util-crypto/src/address/encode.spec.ts
+++ b/packages/util-crypto/src/address/encode.spec.ts
@@ -5,7 +5,7 @@
 import testingPairs from '../../../keyring/src/testingPairs';
 import encode from './encode';
 
-const keyring = testingPairs({ type: 'ed25519' }, false);
+const keyring = testingPairs({ defaultType: 'ed25519' }, false);
 
 describe('encode', (): void => {
   it('encodes an address to a valid value', (): void => {


### PR DESCRIPTION
Changes the keyring constructor parameter's name from `type` to `defaultType`. This change makes it more clear that the keyring is not restricted to storing only one type of keys, but rather that new keys will be given this type if a type is not explicitly provided.