### PR TITLE
Allow forcing of units in formatBalance

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",
-    "@polkadot/dev": "^0.32.0-beta.11",
-    "@polkadot/ts": "^0.1.82",
+    "@polkadot/dev": "^0.32.0-beta.12",
+    "@polkadot/ts": "^0.1.83",
     "gh-pages": "^2.1.1"
   }
 }

--- a/packages/util/src/format/formatBalance.spec.ts
+++ b/packages/util/src/format/formatBalance.spec.ts
@@ -9,80 +9,108 @@ import formatBalance from './formatBalance';
 describe('formatBalance', (): void => {
   const TESTVAL = new BN('123456789000');
 
-  it('formats empty to 0', (): void => {
-    expect(formatBalance()).toEqual('0');
-    expect(formatBalance('0')).toEqual('0');
+  describe('SI formatting', (): void => {
+    it('formats empty to 0', (): void => {
+      expect(formatBalance()).toEqual('0');
+      expect(formatBalance('0')).toEqual('0');
+    });
+
+    it('formats 123,456,789,000 (decimals=15)', (): void => {
+      expect(
+        formatBalance(TESTVAL, true, 15)
+      ).toEqual('123.456µ Unit');
+    });
+
+    it('formats 123,456,789,000 (decimals=36)', (): void => {
+      expect(
+        formatBalance(TESTVAL, true, 36)
+      ).toEqual('0.123y Unit');
+    });
+
+    it('formats 123,456,789,000 (decimals=15, Compact)', (): void => {
+      const compact = {
+        toBn: (): BN => TESTVAL,
+        unwrap: (): BN => TESTVAL,
+        something: 'else'
+      };
+      expect(
+        formatBalance(compact, true, 15)
+      ).toEqual('123.456µ Unit');
+    });
+
+    it('formats 123,456,789,000 (decimals=12)', (): void => {
+      expect(
+        formatBalance(TESTVAL, true, 12)
+      ).toEqual('123.456m Unit');
+    });
+
+    it('formats 123,456,789,000 (decimals=12, no SI)', (): void => {
+      expect(
+        formatBalance(TESTVAL, false, 12)
+      ).toEqual('123.456');
+    });
+
+    it('formats 123,456,789,000 (decimals=9)', (): void => {
+      expect(
+        formatBalance(TESTVAL, true, 9)
+      ).toEqual('123.456 Unit');
+    });
+
+    it('formats 123,456,789,000 (decimals=6)', (): void => {
+      expect(
+        formatBalance(TESTVAL, true, 6)
+      ).toEqual('123.456k Unit');
+    });
+
+    it('formats 123,456,789,000 * 10 (decimals=12)', (): void => {
+      expect(
+        formatBalance(TESTVAL.muln(10), true, 12)
+      ).toEqual('1.234 Unit');
+    });
+
+    it('formats 123,456,789,000 * 100 (decimals=12)', (): void => {
+      expect(
+        formatBalance(TESTVAL.muln(100), true, 12)
+      ).toEqual('12.345 Unit');
+    });
+
+    it('formats 123,456,789,000 * 1000 (decimals=12)', (): void => {
+      expect(
+        formatBalance(TESTVAL.muln(1000), true, 12)
+      ).toEqual('123.456 Unit');
+    });
+
+    it('formats -123,456,789,000 (decimals=15)', (): void => {
+      expect(
+        formatBalance(new BN('-123456789000'), true, 15)
+      ).toEqual('-123.456µ Unit');
+    });
   });
 
-  it('formats 123,456,789,000 (decimals=15)', (): void => {
-    expect(
-      formatBalance(TESTVAL, true, 15)
-    ).toEqual('123.456µ Unit');
-  });
+  describe('Forced formatting', (): void => {
+    it('formats 123,456,789,000 (decimals=12, forceUnit=base)', (): void => {
+      expect(
+        formatBalance(TESTVAL, { forceUnit: '-' }, 12)
+      ).toEqual('0.123 Unit');
+    });
 
-  it('formats 123,456,789,000 (decimals=36)', (): void => {
-    expect(
-      formatBalance(TESTVAL, true, 36)
-    ).toEqual('0.123y Unit');
-  });
+    it('formats 123,456,789,000 (decimals=9, forceUnit=base)', (): void => {
+      expect(
+        formatBalance(TESTVAL, { forceUnit: '-' }, 9)
+      ).toEqual('123.456 Unit');
+    });
 
-  it('formats 123,456,789,000 (decimals=15, Compact)', (): void => {
-    const compact = {
-      toBn: (): BN => TESTVAL,
-      unwrap: (): BN => TESTVAL,
-      something: 'else'
-    };
-    expect(
-      formatBalance(compact, true, 15)
-    ).toEqual('123.456µ Unit');
-  });
+    it('formats 123,456,789,000 (decimals=7, forceUnit=base)', (): void => {
+      expect(
+        formatBalance(TESTVAL, { forceUnit: '-' }, 7)
+      ).toEqual('12,345.678 Unit');
+    });
 
-  it('formats 123,456,789,000 (decimals=12)', (): void => {
-    expect(
-      formatBalance(TESTVAL, true, 12)
-    ).toEqual('123.456m Unit');
-  });
-
-  it('formats 123,456,789,000 (decimals=12, no SI)', (): void => {
-    expect(
-      formatBalance(TESTVAL, false, 12)
-    ).toEqual('123.456');
-  });
-
-  it('formats 123,456,789,000 (decimals=9)', (): void => {
-    expect(
-      formatBalance(TESTVAL, true, 9)
-    ).toEqual('123.456 Unit');
-  });
-
-  it('formats 123,456,789,000 (decimals=6)', (): void => {
-    expect(
-      formatBalance(TESTVAL, true, 6)
-    ).toEqual('123.456k Unit');
-  });
-
-  it('formats 123,456,789,000 * 10 (decimals=12)', (): void => {
-    expect(
-      formatBalance(TESTVAL.muln(10), true, 12)
-    ).toEqual('1.234 Unit');
-  });
-
-  it('formats 123,456,789,000 * 100 (decimals=12)', (): void => {
-    expect(
-      formatBalance(TESTVAL.muln(100), true, 12)
-    ).toEqual('12.345 Unit');
-  });
-
-  it('formats 123,456,789,000 * 1000 (decimals=12)', (): void => {
-    expect(
-      formatBalance(TESTVAL.muln(1000), true, 12)
-    ).toEqual('123.456 Unit');
-  });
-
-  it('formats -123,456,789,000 (decimals=15)', (): void => {
-    expect(
-      formatBalance(new BN('-123456789000'), true, 15)
-    ).toEqual('-123.456µ Unit');
+    it('formats 123,456,789,000 (decimals=15, forceUnit=µ)', (): void => {
+      expect(
+        formatBalance(TESTVAL, { forceUnit: 'µ' }, 15)
+      ).toEqual('123.456µ Unit');
+    });
   });
 
   describe('calcSi', (): void => {

--- a/packages/util/src/format/si.ts
+++ b/packages/util/src/format/si.ts
@@ -26,11 +26,6 @@ export const SI: SiDef[] = [
   { power: 24, value: 'Y', text: 'Yotta' }
 ];
 
-export function calcSi (text: string, decimals: number): SiDef {
-  const siDefIndex = (SI_MID - 1) + Math.ceil((text.length - decimals) / 3);
-  return SI[siDefIndex] || SI[siDefIndex < 0 ? 0 : SI.length - 1];
-}
-
 // Given a SI type (e.g. k, m, Y) find the SI definition
 export function findSi (type: string): SiDef {
   // use a loop here, better RN support (which doesn't have [].find)
@@ -41,4 +36,14 @@ export function findSi (type: string): SiDef {
   }
 
   return SI[SI_MID];
+}
+
+export function calcSi (text: string, decimals: number, forceUnit?: string): SiDef {
+  if (forceUnit) {
+    return findSi(forceUnit);
+  }
+
+  const siDefIndex = (SI_MID - 1) + Math.ceil((text.length - decimals) / 3);
+
+  return SI[siDefIndex] || SI[siDefIndex < 0 ? 0 : SI.length - 1];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,10 +1790,10 @@
   dependencies:
     "@types/node" "^12.11.1"
 
-"@polkadot/dev@^0.32.0-beta.11":
-  version "0.32.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.32.0-beta.11.tgz#930332443807db0c0f692d959ca18c7a84037be1"
-  integrity sha512-qowTLH6OI/ujmRki5N+QpCCYlyuwpI59IP/XNOw7IhpM/6CbxCdxsdGaoELCtxEIAeRMH2IksqD3eoU5YK8LxA==
+"@polkadot/dev@^0.32.0-beta.12":
+  version "0.32.0-beta.12"
+  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.32.0-beta.12.tgz#0c11d980c445c51ce6262d0a113ea4ca2d105d77"
+  integrity sha512-jHGH5y1yuZP1ZQMrqdWFtE8jFznrD6zkDPY2m209G6dL+jTlDw/NRWyBP+zHzhXMT3JSFyw7dcBNCdmecXUnMA==
   dependencies:
     "@babel/cli" "^7.6.4"
     "@babel/core" "^7.6.4"
@@ -1836,10 +1836,10 @@
     typescript "^3.6.4"
     vuepress "^1.2.0"
 
-"@polkadot/ts@^0.1.82":
-  version "0.1.82"
-  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.82.tgz#e9c9742dcb4096358d740d1476c307595f97c9f9"
-  integrity sha512-7rC56/fb/ubwZ3k+zn3yf+HTmjXGy+IobDbO8+P/0REXj+MkhQp4ns3tMuIfanWZEp4S/bqwU7BvgyvvodGfCA==
+"@polkadot/ts@^0.1.83":
+  version "0.1.83"
+  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.83.tgz#9aa7cc96f66a79d6744d922707f52b62ab374143"
+  integrity sha512-cBIWE60GK/QtyEOpN+NmdKmBcMGdMzm5KgLjfiJaJBcSGFzI1Cd3+z1SPVwzy8Yk0bmdhxHij4lF9A9jEik9fQ==
   dependencies:
     "@types/chrome" "^0.0.91"
 


### PR DESCRIPTION
This allows the formatting of a balance to a specific SI unit, instead of a calculated one. i.e. `formatBalance(123456, { forceUnit: '-' })` will format as `123,456.000`