### PR TITLE
Avoid default import

### DIFF
--- a/packages/util-crypto/src/key/DeriveJunction.ts
+++ b/packages/util-crypto/src/key/DeriveJunction.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import BN from 'bn.js';
+import * as BN from 'bn.js';
 import { bnToHex, compactAddLength, hexToU8a, isBn, isHex, isNumber, isString, stringToU8a } from '@polkadot/util';
 
 import blake2AsU8a from '../blake2/asU8a';


### PR DESCRIPTION
This is a blocker when integrating with some libraries. Notably, it breaks the address-encoder build for ENS: https://github.com/ensdomains/address-encoder/pull/23

Changing to this syntax fixes things.