### PR TITLE
ss58: add Kulupu prefix to the list

### DIFF
--- a/packages/util-crypto/src/address/ss58.ts
+++ b/packages/util-crypto/src/address/ss58.ts
@@ -7,6 +7,8 @@ export const allowedSS58 = [
   0, 1,
   // Kusama
   2, 3,
+  // Kulupu
+  16, 17,
   // Dothereum
   20,
   // Substrate default


### PR DESCRIPTION
This adds Kulupu prefix 16 (mainnet) and 17 (reserved) to the list of `allowedSS58`.