### PR TITLE
Adjust DeriveJunction (types & BigInt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.10.0-beta.x
 
 - Make the `TextEncoder` polyfill handle non-compliant Buffer implementations (newer versions of Jest)
+- `DeriveJunction` now also allows for BigInt values (aligning with number types elsewhere)
 
 # 2.9.1 Apr 30, 2020
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",
-    "@polkadot/dev": "^0.52.17",
-    "@polkadot/ts": "^0.3.20",
+    "@polkadot/dev": "^0.52.18",
+    "@polkadot/ts": "^0.3.21",
     "@types/jest": "^25.2.1"
   }
 }

--- a/packages/util-crypto/src/key/DeriveJunction.ts
+++ b/packages/util-crypto/src/key/DeriveJunction.ts
@@ -2,8 +2,9 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import BN from 'bn.js';
-import { bnToHex, compactAddLength, hexToU8a, isBn, isHex, isNumber, isString, stringToU8a } from '@polkadot/util';
+import type BN from 'bn.js';
+
+import { bnToHex, compactAddLength, hexToU8a, isBigInt, isBn, isHex, isNumber, isString, stringToU8a } from '@polkadot/util';
 
 import blake2AsU8a from '../blake2/asU8a';
 
@@ -21,10 +22,10 @@ export default class DeriveJunction {
   #isHard = false;
 
   public static from (value: string): DeriveJunction {
+    const result = new DeriveJunction();
     const [code, isHard] = value.startsWith('/')
       ? [value.substr(1), true]
       : [value, false];
-    const result = new DeriveJunction();
 
     result.soft(
       RE_NUMBER.test(code)
@@ -49,7 +50,7 @@ export default class DeriveJunction {
     return !this.#isHard;
   }
 
-  public hard (value: number | BN | string | Uint8Array): DeriveJunction {
+  public hard (value: number | string | BigInt | BN | Uint8Array): DeriveJunction {
     return this.soft(value).harden();
   }
 
@@ -59,8 +60,8 @@ export default class DeriveJunction {
     return this;
   }
 
-  public soft (value: number | BN | string | Uint8Array): DeriveJunction {
-    if (isNumber(value) || isBn(value)) {
+  public soft (value: number | string | BigInt | BN | Uint8Array): DeriveJunction {
+    if (isNumber(value) || isBn(value) || isBigInt(value)) {
       return this.soft(bnToHex(value, BN_OPTIONS));
     } else if (isString(value)) {
       return isHex(value)

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import BN from 'bn.js';
+import type BN from 'bn.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Constructor<T = any> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,9 +2626,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/dev@npm:^0.52.17":
-  version: 0.52.17
-  resolution: "@polkadot/dev@npm:0.52.17"
+"@polkadot/dev@npm:^0.52.18":
+  version: 0.52.18
+  resolution: "@polkadot/dev@npm:0.52.18"
   dependencies:
     "@babel/cli": ^7.8.4
     "@babel/core": ^7.9.6
@@ -2709,7 +2709,7 @@ __metadata:
     polkadot-exec-typedoc: scripts/polkadot-exec-typedoc.js
     polkadot-exec-vuepress: scripts/polkadot-exec-vuepress.js
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.js
-  checksum: 3/a3fd036ad89834ea6699a06f4b38fe9816e7f1b7ffec759e5f7ca396767e02219f6b0089bd48202bda22970fe6cd876f43ba86389d7adeb7009d0afb57cd4c98
+  checksum: 3/9ec929504aad48ad97c93cb33c18c4a6d0e86dca66212374c6679e7259b85a18a4bf866dcaba7d0f5ab03cfcbe055e102acff0f28ec6d5597bd6ba809a0204ea
   languageName: node
   linkType: hard
 
@@ -2723,12 +2723,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/ts@npm:^0.3.20":
-  version: 0.3.20
-  resolution: "@polkadot/ts@npm:0.3.20"
+"@polkadot/ts@npm:^0.3.21":
+  version: 0.3.21
+  resolution: "@polkadot/ts@npm:0.3.21"
   dependencies:
     "@types/chrome": ^0.0.107
-  checksum: 3/8b7158d5cea034caa7a3e776a2aa25d2e74722d80da5389069d35f9874c2aa5fedec3597c7de0ab04628f61fd3441134039b1ffddad5df8c4923c5dc161d3232
+  checksum: 3/5d6ccc6506213b9437d7c19e3e92381f5772bb1ab7107a9438559bb11be62cd46857e974f710acefa59fa8d371a72980c4647e29e709479ee9e99d986503ff70
   languageName: node
   linkType: hard
 
@@ -15269,8 +15269,8 @@ fsevents@^2.1.2:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@babel/core": ^7.9.6
-    "@polkadot/dev": ^0.52.17
-    "@polkadot/ts": ^0.3.20
+    "@polkadot/dev": ^0.52.18
+    "@polkadot/ts": ^0.3.21
     "@types/jest": ^25.2.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Also closes https://github.com/polkadot-js/common/pull/504 by using `import type` to indicate actual usage.