### PR TITLE
Allow encoding with 0 as ss58 prefix

### DIFF
--- a/packages/util-crypto/src/address/encode.spec.ts
+++ b/packages/util-crypto/src/address/encode.spec.ts
@@ -21,6 +21,12 @@ describe('encode', (): void => {
     ).toEqual('7sL6eNJj5ZGV5cn3hhV2deRUsivXfBfMH76wCALCqWj1EKzv');
   });
 
+  it('can re-encode an address to Polkadot live', (): void => {
+    expect(
+      encode('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', 0)
+    ).toEqual('15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5');
+  });
+
   it('fails when non-valid publicKey provided', (): void => {
     expect(
       (): string => encode(

--- a/packages/util-crypto/src/address/encode.ts
+++ b/packages/util-crypto/src/address/encode.ts
@@ -13,7 +13,9 @@ import decode from './decode';
 import defaults from './defaults';
 import sshash from './sshash';
 
-export default function encode (_key: Uint8Array | string, ss58Format: Prefix = defaults.prefix): string {
+export default function encode (_key: Uint8Array | string, _ss58Format: Prefix): string {
+
+  const ss58Format = ss58Format || ss58Format === 0 ? ss58Format : defaults.prefix;
   // decode it, this means we can re-encode an address
   const key = decode(_key);
 

--- a/packages/util-crypto/src/address/encode.ts
+++ b/packages/util-crypto/src/address/encode.ts
@@ -15,7 +15,7 @@ import sshash from './sshash';
 
 export default function encode (_key: Uint8Array | string, _ss58Format: Prefix): string {
 
-  const ss58Format = ss58Format || ss58Format === 0 ? ss58Format : defaults.prefix;
+  const ss58Format = _ss58Format || _ss58Format === 0 ? _ss58Format : defaults.prefix;
   // decode it, this means we can re-encode an address
   const key = decode(_key);
 


### PR DESCRIPTION
The default value for this param is applied even if 0 (a valid argument) is passed as ss58Prefix.