### PR TITLE
Keyring JSON with kdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.0.0-beta.x
+
+- Adjust JSON pair output with scrypt kdf (version 3 output)
+
 ## 2.18.1 Jul 13, 2020
 
 - Add `base64{Decode, Encode, Validate}` as crypto utils

--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.19.0-beta.2"
+  "version": "3.0.0-beta.0"
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "@polkadot/ts": "^0.3.29",
     "@types/jest": "^26.0.4"
   },
-  "version": "2.19.0-beta.2"
+  "version": "3.0.0-beta.0"
 }

--- a/packages/keyring/package.json
+++ b/packages/keyring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/keyring",
-  "version": "2.19.0-beta.2",
+  "version": "3.0.0-beta.0",
   "description": "Keyring management",
   "main": "index.js",
   "publishConfig": {
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/polkadot-js/common/tree/master/packages/keyring#readme",
   "dependencies": {
     "@babel/runtime": "^7.10.5",
-    "@polkadot/util": "2.19.0-beta.2",
-    "@polkadot/util-crypto": "2.19.0-beta.2"
+    "@polkadot/util": "3.0.0-beta.0",
+    "@polkadot/util-crypto": "3.0.0-beta.0"
   }
 }

--- a/packages/keyring/src/index.spec.ts
+++ b/packages/keyring/src/index.spec.ts
@@ -235,7 +235,8 @@ describe('keypair', (): void => {
 
   describe('version 2 JSON', (): void => {
     const PAIR = '{"address":"5CczAE5AmGrZ93MeVhha3Ywam7j9dKB7cArnH7gtrXcMFJvu","encoded":"0xee8f236e2ac3217ce689692a4afc612220dc77fddaed0482f8f95136a7c3e034cccfbc495410a6e9b2439904974ed1d207abeca536ff6985ceb78edeeb3dc343e561c184c488101af8811d1331430b4ccf0e96ef507132e5132964e8564232e7100d973c5bee7b231dd0c8ad5273f3501515a422c8d7ed9d20a73c0ed17c98ee4588e54844bb73052dcad81f7a1094613d63c162fec7446c88b1fae70e","encoding":{"content":["pkcs8","sr25519"],"type":"xsalsa20-poly1305","version":"2"},"meta":{"genesisHash":"0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e","name":"json v2","tags":[],"whenCreated":1595243159596}}';
-    const PASS = 'versionTwo';
+    const PASS2 = 'versionTwo';
+    const PASS3 = 'versionThree';
     let keyring: Keyring;
 
     beforeEach((): void => {
@@ -245,10 +246,20 @@ describe('keypair', (): void => {
     it('can decode from a version 2 JSON file', (): void => {
       const pair = keyring.addFromJson(JSON.parse(PAIR));
 
+      pair.decodePkcs8(PASS2);
+
+      const json = pair.toJson(PASS3);
+
+      expect(pair.isLocked).toBe(false);
+      expect(json.encoding).toEqual({
+        content: ['pkcs8', 'sr25519'],
+        type: ['scrypt', 'xsalsa20-poly1305'],
+        version: '3'
+      });
+
+      pair.decodePkcs8(PASS3);
+
       expect(pair.address).toEqual('5CczAE5AmGrZ93MeVhha3Ywam7j9dKB7cArnH7gtrXcMFJvu');
-      expect(
-        () => pair.decodePkcs8(PASS)
-      ).not.toThrow();
     });
   });
 });

--- a/packages/keyring/src/index.spec.ts
+++ b/packages/keyring/src/index.spec.ts
@@ -232,4 +232,23 @@ describe('keypair', (): void => {
       ).toEqual('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY');
     });
   });
+
+  describe('version 2 JSON', (): void => {
+    const PAIR = '{"address":"5CczAE5AmGrZ93MeVhha3Ywam7j9dKB7cArnH7gtrXcMFJvu","encoded":"0xee8f236e2ac3217ce689692a4afc612220dc77fddaed0482f8f95136a7c3e034cccfbc495410a6e9b2439904974ed1d207abeca536ff6985ceb78edeeb3dc343e561c184c488101af8811d1331430b4ccf0e96ef507132e5132964e8564232e7100d973c5bee7b231dd0c8ad5273f3501515a422c8d7ed9d20a73c0ed17c98ee4588e54844bb73052dcad81f7a1094613d63c162fec7446c88b1fae70e","encoding":{"content":["pkcs8","sr25519"],"type":"xsalsa20-poly1305","version":"2"},"meta":{"genesisHash":"0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e","name":"json v2","tags":[],"whenCreated":1595243159596}}';
+    const PASS = 'versionTwo';
+    let keyring: Keyring;
+
+    beforeEach((): void => {
+      keyring = new Keyring({ ss58Format: 42 });
+    });
+
+    it('can decode from a version 2 JSON file', (): void => {
+      const pair = keyring.addFromJson(JSON.parse(PAIR));
+
+      expect(pair.address).toEqual('5CczAE5AmGrZ93MeVhha3Ywam7j9dKB7cArnH7gtrXcMFJvu');
+      expect(
+        () => pair.decodePkcs8(PASS)
+      ).not.toThrow();
+    });
+  });
 });

--- a/packages/keyring/src/index.spec.ts
+++ b/packages/keyring/src/index.spec.ts
@@ -251,6 +251,7 @@ describe('keypair', (): void => {
       const json = pair.toJson(PASS3);
 
       expect(pair.isLocked).toBe(false);
+      expect(pair.address).toBe('5CczAE5AmGrZ93MeVhha3Ywam7j9dKB7cArnH7gtrXcMFJvu');
       expect(json.encoding).toEqual({
         content: ['pkcs8', 'sr25519'],
         type: ['scrypt', 'xsalsa20-poly1305'],
@@ -260,6 +261,44 @@ describe('keypair', (): void => {
       pair.decodePkcs8(PASS3);
 
       expect(pair.address).toEqual('5CczAE5AmGrZ93MeVhha3Ywam7j9dKB7cArnH7gtrXcMFJvu');
+    });
+  });
+
+  describe('version 3 JSON (hex)', (): void => {
+    const PAIR = '{"address":"FLiSDPCcJ6auZUGXALLj6jpahcP6adVFDBUQznPXUQ7yoqH","encoded":"0xcd238963070cc4d6806053ee1ac500c7add9c28732bb5d434a332f84a91d9be0008000000100000008000000cf630a1113941b350ddd06697e50399183162e5e9a0e893eafc7f5f4893a223dca5055706b9925b56fdb4304192143843da718e11717daf89cf4f4781f94fb443f61432f782d54280af9eec90bd3069c3cc2d957a42b7c18dc2e9497f623735518e0e49b58f8e4db2c09da3a45dbb935659d015fc94b946cba75b606a6ff7f4e823f6b049e2e6892026b49de02d6dbbd64646fe0933f537d9ea53a70be","encoding":{"content":["pkcs8","sr25519"],"type":["scrypt","xsalsa20-poly1305"],"version":"3"},"meta":{"genesisHash":"0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe","name":"version3","tags":[],"whenCreated":1595277797639}}';
+    const PASS3 = 'version3';
+    let keyring: Keyring;
+
+    beforeEach((): void => {
+      keyring = new Keyring({ ss58Format: 2 });
+    });
+
+    it('can decode from a version 3 JSON file', (): void => {
+      const pair = keyring.addFromJson(JSON.parse(PAIR));
+
+      pair.decodePkcs8(PASS3);
+
+      expect(pair.isLocked).toBe(false);
+      expect(pair.address).toBe('FLiSDPCcJ6auZUGXALLj6jpahcP6adVFDBUQznPXUQ7yoqH');
+    });
+  });
+
+  describe('version 3 JSON (base64)', (): void => {
+    const PAIR = '{"address":"FLiSDPCcJ6auZUGXALLj6jpahcP6adVFDBUQznPXUQ7yoqH","encoded":"ILjSgYaGvq1zaCz/kx+aqfLaHBjLXz0Qsmr6RnkOVU4AgAAAAQAAAAgAAAB5R2hm5kgXyc0NQYFxvMU4zCdjB+ugs/ibEooqCvuudbaeKn3Ee47NkCqU1ecOJV+eeaVn4W4dRvIpj5kGmQOGsewR+MiQ/B0G9NFh7JXV0qcPlk2QMNW1/mbJrTO4miqL448BSkP7ZOhUV6HFUpMt3B9HwjiRLN8RORcFp0ID/Azs4Jl/xOpXNzbgQGIffWgCIKTxN9N1ku6tdlG4","encoding":{"content":["pkcs8","sr25519"],"type":["scrypt","xsalsa20-poly1305"],"version":"3"},"meta":{"genesisHash":"0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe","name":"version3","tags":[],"whenCreated":1595277797639,"whenEdited":1595278378596}}';
+    const PASS3 = 'version3';
+    let keyring: Keyring;
+
+    beforeEach((): void => {
+      keyring = new Keyring({ ss58Format: 2 });
+    });
+
+    it('can decode from a version 3 JSON file', (): void => {
+      const pair = keyring.addFromJson(JSON.parse(PAIR));
+
+      pair.decodePkcs8(PASS3);
+
+      expect(pair.isLocked).toBe(false);
+      expect(pair.address).toBe('FLiSDPCcJ6auZUGXALLj6jpahcP6adVFDBUQznPXUQ7yoqH');
     });
   });
 });

--- a/packages/keyring/src/keyring.ts
+++ b/packages/keyring/src/keyring.ts
@@ -6,7 +6,7 @@ import { KeypairType, Keypair } from '@polkadot/util-crypto/types';
 import { KeyringInstance, KeyringPair, KeyringPair$Json, KeyringPair$JsonEncodingTypes, KeyringPair$Meta, KeyringOptions } from './types';
 
 import { assert, hexToU8a, isHex, isUndefined, stringToU8a } from '@polkadot/util';
-import { decodeAddress, encodeAddress, keyExtractSuri, keyFromPath, naclKeypairFromSeed as naclFromSeed, schnorrkelKeypairFromSeed as schnorrkelFromSeed, secp256k1KeypairFromSeed as secp256k1FromSeed, mnemonicToMiniSecret } from '@polkadot/util-crypto';
+import { base64Decode, decodeAddress, encodeAddress, keyExtractSuri, keyFromPath, naclKeypairFromSeed as naclFromSeed, schnorrkelKeypairFromSeed as schnorrkelFromSeed, secp256k1KeypairFromSeed as secp256k1FromSeed, mnemonicToMiniSecret } from '@polkadot/util-crypto';
 
 import { DEV_PHRASE } from './defaults';
 import createPair from './pair';
@@ -105,7 +105,7 @@ export default class Keyring implements KeyringInstance {
       ? [type]
       : type;
 
-    return this.addFromAddress(address, meta, hexToU8a(encoded), cryptoType, ignoreChecksum, encType);
+    return this.addFromAddress(address, meta, isHex(encoded) ? hexToU8a(encoded) : base64Decode(encoded), cryptoType, ignoreChecksum, encType);
   }
 
   /**

--- a/packages/keyring/src/keyring.ts
+++ b/packages/keyring/src/keyring.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { KeypairType, Keypair } from '@polkadot/util-crypto/types';
-import { KeyringInstance, KeyringPair, KeyringPair$Json, KeyringPair$Meta, KeyringOptions } from './types';
+import { KeyringInstance, KeyringPair, KeyringPair$Json, KeyringPair$JsonEncodingTypes, KeyringPair$Meta, KeyringOptions } from './types';
 
 import { assert, hexToU8a, isHex, isUndefined, stringToU8a } from '@polkadot/util';
 import { decodeAddress, encodeAddress, keyExtractSuri, keyFromPath, naclKeypairFromSeed as naclFromSeed, schnorrkelKeypairFromSeed as schnorrkelFromSeed, secp256k1KeypairFromSeed as secp256k1FromSeed, mnemonicToMiniSecret } from '@polkadot/util-crypto';
@@ -84,10 +84,10 @@ export default class Keyring implements KeyringInstance {
    * of an account backup), and then generates a keyring pair from them that it passes to
    * `addPair` to stores in a keyring pair dictionary the public key of the generated pair as a key and the pair as the associated value.
    */
-  public addFromAddress (address: string | Uint8Array, meta: KeyringPair$Meta = {}, encoded: Uint8Array | null = null, type: KeypairType = this.type, ignoreChecksum?: boolean): KeyringPair {
+  public addFromAddress (address: string | Uint8Array, meta: KeyringPair$Meta = {}, encoded: Uint8Array | null = null, type: KeypairType = this.type, ignoreChecksum?: boolean, encType?: KeyringPair$JsonEncodingTypes[]): KeyringPair {
     const publicKey = this.decodeAddress(address, ignoreChecksum);
 
-    return this.addPair(createPair({ toSS58: this.encodeAddress, type }, { publicKey, secretKey: new Uint8Array() }, meta, encoded));
+    return this.addPair(createPair({ toSS58: this.encodeAddress, type }, { publicKey, secretKey: new Uint8Array() }, meta, encoded, encType));
   }
 
   /**
@@ -97,12 +97,15 @@ export default class Keyring implements KeyringInstance {
    * of an account backup), and then generates a keyring pair from it that it passes to
    * `addPair` to stores in a keyring pair dictionary the public key of the generated pair as a key and the pair as the associated value.
    */
-  public addFromJson ({ address, encoded, encoding: { content, version }, meta }: KeyringPair$Json, ignoreChecksum?: boolean): KeyringPair {
-    const type = version === '0' || !Array.isArray(content)
+  public addFromJson ({ address, encoded, encoding: { content, type, version }, meta }: KeyringPair$Json, ignoreChecksum?: boolean): KeyringPair {
+    const cryptoType = version === '0' || !Array.isArray(content)
       ? this.type
       : content[1];
+    const encType = !Array.isArray(type)
+      ? [type]
+      : type;
 
-    return this.addFromAddress(address, meta, hexToU8a(encoded), type, ignoreChecksum);
+    return this.addFromAddress(address, meta, hexToU8a(encoded), cryptoType, ignoreChecksum, encType);
   }
 
   /**

--- a/packages/keyring/src/pair/decode.ts
+++ b/packages/keyring/src/pair/decode.ts
@@ -43,7 +43,7 @@ function decodePkcs8 (encoded: Uint8Array): DecodeResult {
   };
 }
 
-export default function decode (passphrase?: string, encrypted?: Uint8Array | null, encType: KeyringPair$JsonEncodingTypes[] = ['xsalsa20-poly1305']): DecodeResult {
+export default function decode (passphrase?: string, encrypted?: Uint8Array | null, encType: KeyringPair$JsonEncodingTypes[] = ['pbkdf2', 'xsalsa20-poly1305']): DecodeResult {
   assert(encrypted, 'No encrypted data available to decode');
 
   let encoded: Uint8Array | null = encrypted;

--- a/packages/keyring/src/pair/defaults.ts
+++ b/packages/keyring/src/pair/defaults.ts
@@ -6,6 +6,7 @@ const NONCE_LENGTH = 24;
 const PKCS8_DIVIDER = new Uint8Array([161, 35, 3, 33, 0]);
 const PKCS8_HEADER = new Uint8Array([48, 83, 2, 1, 1, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32]);
 const PUB_LENGTH = 32;
+const SALT_LENGTH = 32;
 const SEC_LENGTH = 64;
 const SEED_LENGTH = 32;
 
@@ -14,6 +15,7 @@ export {
   PKCS8_DIVIDER,
   PKCS8_HEADER,
   PUB_LENGTH,
+  SALT_LENGTH,
   SEC_LENGTH,
   SEED_LENGTH
 };

--- a/packages/keyring/src/pair/defaults.ts
+++ b/packages/keyring/src/pair/defaults.ts
@@ -9,6 +9,7 @@ const PUB_LENGTH = 32;
 const SALT_LENGTH = 32;
 const SEC_LENGTH = 64;
 const SEED_LENGTH = 32;
+const SCRYPT_LENGTH = SALT_LENGTH + (3 * 4);
 
 export {
   NONCE_LENGTH,
@@ -17,5 +18,6 @@ export {
   PUB_LENGTH,
   SALT_LENGTH,
   SEC_LENGTH,
-  SEED_LENGTH
+  SEED_LENGTH,
+  SCRYPT_LENGTH
 };

--- a/packages/keyring/src/pair/encode.spec.ts
+++ b/packages/keyring/src/pair/encode.spec.ts
@@ -3,10 +3,10 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import testingPairs from '../testingPairs';
-import { PKCS8_DIVIDER, PKCS8_HEADER, PUB_LENGTH, SEC_LENGTH } from './defaults';
+import { PKCS8_DIVIDER, PKCS8_HEADER, NONCE_LENGTH, PUB_LENGTH, SALT_LENGTH, SEC_LENGTH } from './defaults';
 
 const PKCS8_LENGTH = PKCS8_DIVIDER.length + PKCS8_HEADER.length + PUB_LENGTH + SEC_LENGTH;
-const ENCODED_LENGTH = 157;
+const ENCODED_LENGTH = 16 + PKCS8_LENGTH + NONCE_LENGTH + SALT_LENGTH;
 
 const keyring = testingPairs({ type: 'ed25519' }, false);
 

--- a/packages/keyring/src/pair/encode.spec.ts
+++ b/packages/keyring/src/pair/encode.spec.ts
@@ -3,10 +3,10 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import testingPairs from '../testingPairs';
-import { PKCS8_DIVIDER, PKCS8_HEADER, NONCE_LENGTH, PUB_LENGTH, SALT_LENGTH, SEC_LENGTH } from './defaults';
+import { PKCS8_DIVIDER, PKCS8_HEADER, NONCE_LENGTH, PUB_LENGTH, SCRYPT_LENGTH, SEC_LENGTH } from './defaults';
 
 const PKCS8_LENGTH = PKCS8_DIVIDER.length + PKCS8_HEADER.length + PUB_LENGTH + SEC_LENGTH;
-const ENCODED_LENGTH = 16 + PKCS8_LENGTH + NONCE_LENGTH + SALT_LENGTH;
+const ENCODED_LENGTH = 16 + PKCS8_LENGTH + NONCE_LENGTH + SCRYPT_LENGTH;
 
 const keyring = testingPairs({ type: 'ed25519' }, false);
 

--- a/packages/keyring/src/pair/encode.ts
+++ b/packages/keyring/src/pair/encode.ts
@@ -4,8 +4,8 @@
 
 import { PairInfo } from './types';
 
-import { stringToU8a, u8aConcat, u8aFixLength, assert } from '@polkadot/util';
-import { naclEncrypt } from '@polkadot/util-crypto';
+import { u8aConcat, assert } from '@polkadot/util';
+import { naclEncrypt, pbkdf2Encode } from '@polkadot/util-crypto';
 
 import { PKCS8_DIVIDER, PKCS8_HEADER } from './defaults';
 
@@ -23,7 +23,8 @@ export default function encode ({ publicKey, secretKey }: PairInfo, passphrase?:
     return encoded;
   }
 
-  const { encrypted, nonce } = naclEncrypt(encoded, u8aFixLength(stringToU8a(passphrase), 256, true));
+  const { password, salt } = pbkdf2Encode(passphrase);
+  const { encrypted, nonce } = naclEncrypt(encoded, password.subarray(0, 32));
 
-  return u8aConcat(nonce, encrypted);
+  return u8aConcat(salt, nonce, encrypted);
 }

--- a/packages/keyring/src/pair/encode.ts
+++ b/packages/keyring/src/pair/encode.ts
@@ -5,7 +5,7 @@
 import { PairInfo } from './types';
 
 import { u8aConcat, assert } from '@polkadot/util';
-import { naclEncrypt, pbkdf2Encode } from '@polkadot/util-crypto';
+import { naclEncrypt, scryptEncode, scryptToU8a } from '@polkadot/util-crypto';
 
 import { PKCS8_DIVIDER, PKCS8_HEADER } from './defaults';
 
@@ -23,8 +23,8 @@ export default function encode ({ publicKey, secretKey }: PairInfo, passphrase?:
     return encoded;
   }
 
-  const { password, salt } = pbkdf2Encode(passphrase);
+  const { params, password, salt } = scryptEncode(passphrase);
   const { encrypted, nonce } = naclEncrypt(encoded, password.subarray(0, 32));
 
-  return u8aConcat(salt, nonce, encrypted);
+  return u8aConcat(scryptToU8a(salt, params), nonce, encrypted);
 }

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -113,6 +113,13 @@ function isLocked (secretKey?: Uint8Array): secretKey is undefined {
  * property that indicates whether the public key value of the `encoded` property is encoded or not.
  */
 export default function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: PairInfo, meta: KeyringPair$Meta = {}, encoded: Uint8Array | null = null, encTypes?: KeyringPair$JsonEncodingTypes[]): KeyringPair {
+  const recode = (passphrase?: string): Uint8Array => {
+    encoded = encode({ publicKey, secretKey }, passphrase); // re-encode, latest version
+    encTypes = undefined; // swap to defaults, latest version follows
+
+    return encoded;
+  };
+
   return {
     get address (): string {
       return toSS58(getAddress(type, publicKey));
@@ -130,8 +137,8 @@ export default function createPair ({ toSS58, type }: Setup, { publicKey, secret
       return type;
     },
     // eslint-disable-next-line sort-keys
-    decodePkcs8: (passphrase?: string, _encoded?: Uint8Array | null): void => {
-      const decoded = decode(passphrase, _encoded || encoded, encTypes);
+    decodePkcs8: (passphrase?: string, userEncoded?: Uint8Array | null): void => {
+      const decoded = decode(passphrase, userEncoded || encoded, encTypes);
 
       if (decoded.secretKey.length === 64) {
         publicKey = decoded.publicKey;
@@ -152,7 +159,7 @@ export default function createPair ({ toSS58, type }: Setup, { publicKey, secret
       return createPair({ toSS58, type }, derived, meta, null);
     },
     encodePkcs8: (passphrase?: string): Uint8Array =>
-      encode({ publicKey, secretKey }, passphrase),
+      recode(passphrase),
     lock: (): void => {
       secretKey = new Uint8Array(0);
     },
@@ -165,7 +172,7 @@ export default function createPair ({ toSS58, type }: Setup, { publicKey, secret
       return sign(type, message, { publicKey, secretKey }, options);
     },
     toJson: (passphrase?: string): KeyringPair$Json =>
-      toJson(type, { address: toSS58(getAddress(type, publicKey)), meta }, encode({ publicKey, secretKey }, passphrase), !!passphrase),
+      toJson(type, { address: toSS58(getAddress(type, publicKey)), meta }, recode(passphrase), !!passphrase),
     verify: (message: Uint8Array, signature: Uint8Array): boolean =>
       verify(type, message, signature, publicKey)
   };

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Keypair, KeypairType } from '@polkadot/util-crypto/types';
-import { KeyringPair, KeyringPair$Json, KeyringPair$Meta, SignOptions } from '../types';
+import { KeyringPair, KeyringPair$Json, KeyringPair$JsonEncodingTypes, KeyringPair$Meta, SignOptions } from '../types';
 import { PairInfo } from './types';
 
 import { assert, u8aConcat } from '@polkadot/util';
@@ -112,7 +112,7 @@ function isLocked (secretKey?: Uint8Array): secretKey is undefined {
  * an `encoded` property that is assigned with the encoded public key in hex format, and an `encoding`
  * property that indicates whether the public key value of the `encoded` property is encoded or not.
  */
-export default function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: PairInfo, meta: KeyringPair$Meta = {}, encoded: Uint8Array | null = null): KeyringPair {
+export default function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: PairInfo, meta: KeyringPair$Meta = {}, encoded: Uint8Array | null = null, encTypes?: KeyringPair$JsonEncodingTypes[]): KeyringPair {
   return {
     get address (): string {
       return toSS58(getAddress(type, publicKey));
@@ -131,7 +131,7 @@ export default function createPair ({ toSS58, type }: Setup, { publicKey, secret
     },
     // eslint-disable-next-line sort-keys
     decodePkcs8: (passphrase?: string, _encoded?: Uint8Array | null): void => {
-      const decoded = decode(passphrase, _encoded || encoded);
+      const decoded = decode(passphrase, _encoded || encoded, encTypes);
 
       if (decoded.secretKey.length === 64) {
         publicKey = decoded.publicKey;

--- a/packages/keyring/src/pair/toJson.spec.ts
+++ b/packages/keyring/src/pair/toJson.spec.ts
@@ -15,8 +15,8 @@ describe('toJson', (): void => {
       encoded: '0x3053020101300506032b657004220420416c696365202020202020202020202020202020202020202020202020202020d172a74cda4c865912c32ba0a80a57ae69abae410e5ccb59dee84e2f4432db4fa123032100d172a74cda4c865912c32ba0a80a57ae69abae410e5ccb59dee84e2f4432db4f',
       encoding: {
         content: ['pkcs8', 'ed25519'],
-        type: 'none',
-        version: '2'
+        type: ['none'],
+        version: '3'
       },
       meta: {
         isTesting: true,
@@ -28,13 +28,13 @@ describe('toJson', (): void => {
   it('creates an encoded output with passphrase', (): void => {
     const json = keyring.alice.toJson('testing');
 
-    expect(json.encoded).toHaveLength(316);
+    expect(json.encoded).toHaveLength(252 + ((32 + 32) * 2));
     expect(json).toMatchObject({
       address: '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaQua',
       encoding: {
         content: ['pkcs8', 'ed25519'],
-        type: 'xsalsa20-poly1305',
-        version: '2'
+        type: ['pbkdf2', 'xsalsa20-poly1305'],
+        version: '3'
       }
     });
   });

--- a/packages/keyring/src/pair/toJson.spec.ts
+++ b/packages/keyring/src/pair/toJson.spec.ts
@@ -28,12 +28,12 @@ describe('toJson', (): void => {
   it('creates an encoded output with passphrase', (): void => {
     const json = keyring.alice.toJson('testing');
 
-    expect(json.encoded).toHaveLength(252 + ((32 + 32) * 2));
+    expect(json.encoded).toHaveLength(252 + ((32 + 32 + 12) * 2));
     expect(json).toMatchObject({
       address: '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaQua',
       encoding: {
         content: ['pkcs8', 'ed25519'],
-        type: ['pbkdf2', 'xsalsa20-poly1305'],
+        type: ['scrypt', 'xsalsa20-poly1305'],
         version: '3'
       }
     });

--- a/packages/keyring/src/pair/toJson.spec.ts
+++ b/packages/keyring/src/pair/toJson.spec.ts
@@ -12,7 +12,7 @@ describe('toJson', (): void => {
       keyring.alice.toJson()
     ).toMatchObject({
       address: '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaQua',
-      encoded: '0x3053020101300506032b657004220420416c696365202020202020202020202020202020202020202020202020202020d172a74cda4c865912c32ba0a80a57ae69abae410e5ccb59dee84e2f4432db4fa123032100d172a74cda4c865912c32ba0a80a57ae69abae410e5ccb59dee84e2f4432db4f',
+      encoded: 'MFMCAQEwBQYDK2VwBCIEIEFsaWNlICAgICAgICAgICAgICAgICAgICAgICAgICAg0XKnTNpMhlkSwyugqApXrmmrrkEOXMtZ3uhOL0Qy20+hIwMhANFyp0zaTIZZEsMroKgKV65pq65BDlzLWd7oTi9EMttP',
       encoding: {
         content: ['pkcs8', 'ed25519'],
         type: ['none'],
@@ -28,7 +28,7 @@ describe('toJson', (): void => {
   it('creates an encoded output with passphrase', (): void => {
     const json = keyring.alice.toJson('testing');
 
-    expect(json.encoded).toHaveLength(252 + ((32 + 32 + 12) * 2));
+    expect(json.encoded).toHaveLength(268);
     expect(json).toMatchObject({
       address: '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaQua',
       encoding: {

--- a/packages/keyring/src/pair/toJson.ts
+++ b/packages/keyring/src/pair/toJson.ts
@@ -22,7 +22,7 @@ export default function toJson (type: KeypairType, { address, meta }: PairStateJ
     encoding: {
       content: ['pkcs8', type],
       type: isEncrypted
-        ? ['pbkdf2', 'xsalsa20-poly1305']
+        ? ['scrypt', 'xsalsa20-poly1305']
         : ['none'],
       version: '3'
     },

--- a/packages/keyring/src/pair/toJson.ts
+++ b/packages/keyring/src/pair/toJson.ts
@@ -12,6 +12,9 @@ interface PairStateJson {
   meta: KeyringPair$Meta;
 }
 
+// version 2 - nonce, encoded (previous)
+// version 3 - salt, nonce, encoded
+
 export default function toJson (type: KeypairType, { address, meta }: PairStateJson, encoded: Uint8Array, isEncrypted: boolean): KeyringPair$Json {
   return {
     address,
@@ -19,9 +22,9 @@ export default function toJson (type: KeypairType, { address, meta }: PairStateJ
     encoding: {
       content: ['pkcs8', type],
       type: isEncrypted
-        ? 'xsalsa20-poly1305'
-        : 'none',
-      version: '2'
+        ? ['pbkdf2', 'xsalsa20-poly1305']
+        : ['none'],
+      version: '3'
     },
     meta
   };

--- a/packages/keyring/src/pair/toJson.ts
+++ b/packages/keyring/src/pair/toJson.ts
@@ -5,7 +5,7 @@
 import { KeypairType } from '@polkadot/util-crypto/types';
 import { KeyringPair$Json, KeyringPair$Meta } from '../types';
 
-import { u8aToHex } from '@polkadot/util';
+import { base64Encode } from '@polkadot/util-crypto';
 
 interface PairStateJson {
   address: string;
@@ -18,7 +18,7 @@ interface PairStateJson {
 export default function toJson (type: KeypairType, { address, meta }: PairStateJson, encoded: Uint8Array, isEncrypted: boolean): KeyringPair$Json {
   return {
     address,
-    encoded: u8aToHex(encoded),
+    encoded: base64Encode(encoded),
     encoding: {
       content: ['pkcs8', type],
       type: isEncrypted

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -12,11 +12,13 @@ export interface KeyringOptions {
 
 export type KeyringPair$Meta = Record<string, unknown>;
 
-export type KeyringPair$JsonVersion = '0' | '1' | '2';
+export type KeyringPair$JsonVersion = '0' | '1' | '2' | '3';
+
+export type KeyringPair$JsonEncodingTypes = 'none' | 'pbkdf2' | 'xsalsa20-poly1305';
 
 export interface KeyringPair$JsonEncoding {
   content: ['pkcs8', KeypairType];
-  type: 'xsalsa20-poly1305' | 'none';
+  type: KeyringPair$JsonEncodingTypes | KeyringPair$JsonEncodingTypes[];
   version: KeyringPair$JsonVersion;
 }
 

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -14,7 +14,7 @@ export type KeyringPair$Meta = Record<string, unknown>;
 
 export type KeyringPair$JsonVersion = '0' | '1' | '2' | '3';
 
-export type KeyringPair$JsonEncodingTypes = 'none' | 'pbkdf2' | 'xsalsa20-poly1305';
+export type KeyringPair$JsonEncodingTypes = 'none' | 'scrypt' | 'xsalsa20-poly1305';
 
 export interface KeyringPair$JsonEncoding {
   content: ['pkcs8', KeypairType];

--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -35,6 +35,7 @@
     "elliptic": "^6.5.3",
     "js-sha3": "^0.8.0",
     "pbkdf2": "^3.1.1",
+    "scryptsy": "^2.1.0",
     "tweetnacl": "^1.0.3",
     "xxhashjs": "^0.2.2"
   },
@@ -42,6 +43,7 @@
     "@types/bn.js": "^4.11.6",
     "@types/elliptic": "^6.4.12",
     "@types/pbkdf2": "^3.0.0",
+    "@types/scryptsy": "^2.0.0",
     "@types/xxhashjs": "^0.2.2"
   }
 }

--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/util-crypto",
-  "version": "2.19.0-beta.2",
+  "version": "3.0.0-beta.0",
   "description": "A collection of useful crypto utilities for @polkadot",
   "main": "index.js",
   "keywords": [
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/polkadot-js/common/tree/master/packages/util-crypto#readme",
   "dependencies": {
     "@babel/runtime": "^7.10.5",
-    "@polkadot/util": "2.19.0-beta.2",
+    "@polkadot/util": "3.0.0-beta.0",
     "@polkadot/wasm-crypto": "^1.2.1",
     "base-x": "^3.0.8",
     "bip39": "^3.0.2",

--- a/packages/util-crypto/src/index.ts
+++ b/packages/util-crypto/src/index.ts
@@ -20,6 +20,7 @@ export * from './nacl';
 export * from './pbkdf2';
 export * from './random';
 export * from './schnorrkel';
+export * from './scrypt';
 export * from './secp256k1';
 export * from './sha512';
 export * from './signature';

--- a/packages/util-crypto/src/index.ts
+++ b/packages/util-crypto/src/index.ts
@@ -17,6 +17,7 @@ export * from './keccak';
 export * from './key';
 export * from './mnemonic';
 export * from './nacl';
+export * from './pbkdf2';
 export * from './random';
 export * from './schnorrkel';
 export * from './secp256k1';

--- a/packages/util-crypto/src/pbkdf2/encode.ts
+++ b/packages/util-crypto/src/pbkdf2/encode.ts
@@ -1,0 +1,21 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { pbkdf2Sync } from 'pbkdf2';
+import { bufferToU8a, u8aToBuffer, u8aToU8a } from '@polkadot/util';
+
+import randomAsU8a from '../random/asU8a';
+
+interface Result {
+  password: Uint8Array;
+  salt: Uint8Array;
+}
+
+export default function pbkdf2Encode (passphrase?: Uint8Array | string, salt = randomAsU8a(), rounds = 64, length = 2048): Result {
+  const password = bufferToU8a(
+    pbkdf2Sync(u8aToBuffer(u8aToU8a(passphrase)), u8aToBuffer(salt), rounds, length)
+  );
+
+  return { password, salt };
+}

--- a/packages/util-crypto/src/pbkdf2/encode.ts
+++ b/packages/util-crypto/src/pbkdf2/encode.ts
@@ -10,6 +10,7 @@ import randomAsU8a from '../random/asU8a';
 
 interface Result {
   password: Uint8Array;
+  rounds: number;
   salt: Uint8Array;
 }
 
@@ -19,5 +20,5 @@ export default function pbkdf2Encode (passphrase?: Uint8Array | string, salt = r
     ? pbkdf2(u8a, salt, rounds)
     : bufferToU8a(pbkdf2Sync(u8aToBuffer(u8a), u8aToBuffer(salt), rounds, 64));
 
-  return { password, salt };
+  return { password, rounds, salt };
 }

--- a/packages/util-crypto/src/pbkdf2/encode.ts
+++ b/packages/util-crypto/src/pbkdf2/encode.ts
@@ -4,6 +4,7 @@
 
 import { pbkdf2Sync } from 'pbkdf2';
 import { bufferToU8a, u8aToBuffer, u8aToU8a } from '@polkadot/util';
+import { isReady, pbkdf2 } from '@polkadot/wasm-crypto';
 
 import randomAsU8a from '../random/asU8a';
 
@@ -12,10 +13,11 @@ interface Result {
   salt: Uint8Array;
 }
 
-export default function pbkdf2Encode (passphrase?: Uint8Array | string, salt = randomAsU8a(), rounds = 64, length = 2048): Result {
-  const password = bufferToU8a(
-    pbkdf2Sync(u8aToBuffer(u8aToU8a(passphrase)), u8aToBuffer(salt), rounds, length)
-  );
+export default function pbkdf2Encode (passphrase?: Uint8Array | string, salt = randomAsU8a(), rounds = 2048): Result {
+  const u8a = u8aToU8a(passphrase);
+  const password = isReady()
+    ? pbkdf2(u8a, salt, rounds)
+    : bufferToU8a(pbkdf2Sync(u8aToBuffer(u8a), u8aToBuffer(salt), rounds, 64));
 
   return { password, salt };
 }

--- a/packages/util-crypto/src/pbkdf2/index.ts
+++ b/packages/util-crypto/src/pbkdf2/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+export { default as pbkdf2Encode } from './encode';

--- a/packages/util-crypto/src/scrypt/defaults.ts
+++ b/packages/util-crypto/src/scrypt/defaults.ts
@@ -1,0 +1,11 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+const DEFAULT_PARAMS = {
+  N: 1 << 15,
+  p: 1,
+  r: 8
+};
+
+export { DEFAULT_PARAMS };

--- a/packages/util-crypto/src/scrypt/encode.ts
+++ b/packages/util-crypto/src/scrypt/encode.ts
@@ -8,18 +8,13 @@ import scrypt from 'scryptsy';
 import { bufferToU8a, u8aToBuffer, u8aToU8a } from '@polkadot/util';
 
 import randomAsU8a from '../random/asU8a';
+import { DEFAULT_PARAMS } from './defaults';
 
 interface Result {
   params: Params,
   password: Uint8Array;
   salt: Uint8Array;
 }
-
-const DEFAULT_PARAMS = {
-  N: 1 << 15,
-  p: 1,
-  r: 8
-};
 
 export default function scryptEncode (passphrase?: Uint8Array | string, salt = randomAsU8a(), params = DEFAULT_PARAMS): Result {
   const password = bufferToU8a(

--- a/packages/util-crypto/src/scrypt/encode.ts
+++ b/packages/util-crypto/src/scrypt/encode.ts
@@ -1,0 +1,30 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { Params } from './types';
+
+import scrypt from 'scryptsy';
+import { bufferToU8a, u8aToBuffer, u8aToU8a } from '@polkadot/util';
+
+import randomAsU8a from '../random/asU8a';
+
+interface Result {
+  params: Params,
+  password: Uint8Array;
+  salt: Uint8Array;
+}
+
+const DEFAULT_PARAMS = {
+  N: 1 << 15,
+  p: 1,
+  r: 8
+};
+
+export default function scryptEncode (passphrase?: Uint8Array | string, salt = randomAsU8a(), params = DEFAULT_PARAMS): Result {
+  const password = bufferToU8a(
+    scrypt(u8aToBuffer(u8aToU8a(passphrase)), u8aToBuffer(salt), params.N, params.r, params.p, 64)
+  );
+
+  return { params, password, salt };
+}

--- a/packages/util-crypto/src/scrypt/fromU8a.ts
+++ b/packages/util-crypto/src/scrypt/fromU8a.ts
@@ -4,7 +4,9 @@
 
 import { Params } from './types';
 
-import { u8aToBn } from '@polkadot/util';
+import { u8aToBn, assert } from '@polkadot/util';
+
+import { DEFAULT_PARAMS } from './defaults';
 
 interface Result {
   params: Params,
@@ -16,6 +18,12 @@ export default function scryptFromU8a (data: Uint8Array): Result {
   const N = u8aToBn(data.subarray(32 + 0, 32 + 4), { isLe: true }).toNumber();
   const p = u8aToBn(data.subarray(32 + 4, 32 + 8), { isLe: true }).toNumber();
   const r = u8aToBn(data.subarray(32 + 8, 32 + 12), { isLe: true }).toNumber();
+
+  // FIXME At this moment we assume these to be fixed params, this is not a great idea since we lose flexibility
+  // and updates for greater security. However we need some protection against carefully-crafted params that can
+  // eat up CPU since these are user inputs. So we need to get very clever here, but atm we only allow the defaults
+  // and if no match, bail out
+  assert(N === DEFAULT_PARAMS.N && p === DEFAULT_PARAMS.p && r === DEFAULT_PARAMS.r, 'Invalid injected scrypt params found');
 
   return { params: { N, p, r }, salt };
 }

--- a/packages/util-crypto/src/scrypt/fromU8a.ts
+++ b/packages/util-crypto/src/scrypt/fromU8a.ts
@@ -1,0 +1,21 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { Params } from './types';
+
+import { u8aToBn } from '@polkadot/util';
+
+interface Result {
+  params: Params,
+  salt: Uint8Array;
+}
+
+export default function scryptFromU8a (data: Uint8Array): Result {
+  const salt = data.subarray(0, 32);
+  const N = u8aToBn(data.subarray(32 + 0, 32 + 4), { isLe: true }).toNumber();
+  const p = u8aToBn(data.subarray(32 + 4, 32 + 8), { isLe: true }).toNumber();
+  const r = u8aToBn(data.subarray(32 + 8, 32 + 12), { isLe: true }).toNumber();
+
+  return { params: { N, p, r }, salt };
+}

--- a/packages/util-crypto/src/scrypt/index.ts
+++ b/packages/util-crypto/src/scrypt/index.ts
@@ -1,0 +1,7 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+export { default as scryptEncode } from './encode';
+export { default as scryptFromU8a } from './fromU8a';
+export { default as scryptToU8a } from './toU8a';

--- a/packages/util-crypto/src/scrypt/toU8a.ts
+++ b/packages/util-crypto/src/scrypt/toU8a.ts
@@ -1,0 +1,16 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { Params } from './types';
+
+import { bnToU8a, u8aConcat } from '@polkadot/util';
+
+export default function scryptToU8a (salt: Uint8Array, { N, p, r }: Params): Uint8Array {
+  return u8aConcat(
+    salt,
+    bnToU8a(N, { bitLength: 32, isLe: true }),
+    bnToU8a(p, { bitLength: 32, isLe: true }),
+    bnToU8a(r, { bitLength: 32, isLe: true })
+  );
+}

--- a/packages/util-crypto/src/scrypt/types.ts
+++ b/packages/util-crypto/src/scrypt/types.ts
@@ -1,0 +1,9 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+export interface Params {
+  N: number;
+  p: number;
+  r: number;
+}

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/util",
-  "version": "2.19.0-beta.2",
+  "version": "3.0.0-beta.0",
   "description": "A collection of useful utilities for @polkadot",
   "main": "index.js",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,8 +2746,8 @@ __metadata:
   resolution: "@polkadot/keyring@workspace:packages/keyring"
   dependencies:
     "@babel/runtime": ^7.10.5
-    "@polkadot/util": 2.19.0-beta.2
-    "@polkadot/util-crypto": 2.19.0-beta.2
+    "@polkadot/util": 3.0.0-beta.0
+    "@polkadot/util-crypto": 3.0.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -2760,12 +2760,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@2.19.0-beta.2, @polkadot/util-crypto@workspace:packages/util-crypto":
+"@polkadot/util-crypto@3.0.0-beta.0, @polkadot/util-crypto@workspace:packages/util-crypto":
   version: 0.0.0-use.local
   resolution: "@polkadot/util-crypto@workspace:packages/util-crypto"
   dependencies:
     "@babel/runtime": ^7.10.5
-    "@polkadot/util": 2.19.0-beta.2
+    "@polkadot/util": 3.0.0-beta.0
     "@polkadot/wasm-crypto": ^1.2.1
     "@types/bn.js": ^4.11.6
     "@types/elliptic": ^6.4.12
@@ -2785,7 +2785,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/util@2.19.0-beta.2, @polkadot/util@workspace:packages/util":
+"@polkadot/util@3.0.0-beta.0, @polkadot/util@workspace:packages/util":
   version: 0.0.0-use.local
   resolution: "@polkadot/util@workspace:packages/util"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,6 +2770,7 @@ __metadata:
     "@types/bn.js": ^4.11.6
     "@types/elliptic": ^6.4.12
     "@types/pbkdf2": ^3.0.0
+    "@types/scryptsy": ^2.0.0
     "@types/xxhashjs": ^0.2.2
     base-x: ^3.0.8
     bip39: ^3.0.2
@@ -2778,6 +2779,7 @@ __metadata:
     elliptic: ^6.5.3
     js-sha3: ^0.8.0
     pbkdf2: ^3.1.1
+    scryptsy: ^2.1.0
     tweetnacl: ^1.0.3
     xxhashjs: ^0.2.2
   languageName: unknown
@@ -3087,6 +3089,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: 3/e6e6613c800aeda63e2331e753e8d21df1a2c9aa7a4bc71ed792a848e4811fc96e609759089355314a2318c76eff1f161499cd242044838ab1e6f56e463ebb9c
+  languageName: node
+  linkType: hard
+
+"@types/scryptsy@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@types/scryptsy@npm:2.0.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: 3/774b1f24ea8ed5a9e8340738093d8d6337449aaf27b78e0e6715d4941ad593b417a34702b55b08888ed235428eb2e8742e888f064cd04d66f85f6464aca37511
   languageName: node
   linkType: hard
 
@@ -15883,6 +15894,13 @@ __metadata:
     ajv: ^6.12.2
     ajv-keywords: ^3.4.1
   checksum: 3/5d3e7c9e532712bbe0b7ba2f0bdbebc88ca3066c00ceb89877667c3c7b7ea5ee65e0ff7ffbf5164ebda43b0726166d4d39b382e91e9554b7ad2f6b06e77f947d
+  languageName: node
+  linkType: hard
+
+"scryptsy@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "scryptsy@npm:2.1.0"
+  checksum: 3/9fd847955caa9d13a6d58a0360ba8fb31f8e7e7da9250b4c09c67db784a0f6dda757bc837313b0860c0e35f84a56ba068394c682dd4fba81c5899d82832aa7d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [x] pbdkf2 for JS/WASM as available
- [x] verification that the flow is sane
- [x] update tests for new
- [x] include tests for old
- [x] include tests for conversion
- [x] end-to-end testing against real
- [x] end-to-end verification on upgrade
- [x] version bump to v3

Still TODO in follow-up PRs in the 3 series -

- WASM scrypt (https://docs.rs/scrypt/0.3.1/scrypt/), currently a bit problematic since the WASM build is still restructured and not quite stable with the upgrades to wasmpack
- https://github.com/polkadot-js/common/issues/638