### PR TITLE
Adding 4 as address type of ss58 for Katal Chain

### DIFF
--- a/packages/util-crypto/src/address/ss58.ts
+++ b/packages/util-crypto/src/address/ss58.ts
@@ -7,6 +7,8 @@ export const allowedSS58 = [
   0, 1,
   // Kusama
   2, 3,
+  // Katal Chain
+  4,
   // Kulupu
   16, 17,
   // Dothereum


### PR DESCRIPTION
Adding 4 as address type of ss58 for Katal Chain