### PR TITLE
Add Dock network id for address generation

### DIFF
--- a/packages/util-crypto/src/address/ss58.ts
+++ b/packages/util-crypto/src/address/ss58.ts
@@ -13,6 +13,8 @@ export const allowedSS58 = [
   16, 17,
   // Dothereum
   20,
+  // Dock testnet and mainnet
+  21, 22,
   // Substrate default
   42, 43,
   // Substrate BBQ (deprecated)


### PR DESCRIPTION
Taking 21 and 22 for testnet and mainnet

Signed-off-by: lovesh <lovesh.bond@gmail.com>