### PR TITLE
Change formatBalance s.t. Unit is prefix instead of postfix

### DIFF
--- a/packages/util/src/format/formatBalance.spec.ts
+++ b/packages/util/src/format/formatBalance.spec.ts
@@ -18,25 +18,25 @@ describe('formatBalance', (): void => {
     it('formats 123,456,789,000 (decimals=15)', (): void => {
       expect(
         formatBalance(TESTVAL, { decimals: 15, withSi: true })
-      ).toEqual('123.456µ Unit');
+      ).toEqual('Unit 123.456µ');
     });
 
     it('formats BigInt numbers', (): void => {
       expect(
         formatBalance(123456789000n, { decimals: 15, withSi: true })
-      ).toEqual('123.456µ Unit');
+      ).toEqual('Unit 123.456µ');
     });
 
     it('formats 123,456,789,000 (decimals=15, old style)', (): void => {
       expect(
         formatBalance(TESTVAL, { withSi: true }, 15)
-      ).toEqual('123.456µ Unit');
+      ).toEqual('Unit 123.456µ');
     });
 
     it('formats 123,456,789,000 (decimals=36, option)', (): void => {
       expect(
         formatBalance(TESTVAL, { decimals: 36, withSi: true })
-      ).toEqual('0.123y Unit');
+      ).toEqual('Unit 0.123y');
     });
 
     it('formats 123,456,789,000 (decimals=15, Compact)', (): void => {
@@ -48,19 +48,19 @@ describe('formatBalance', (): void => {
 
       expect(
         formatBalance(compact, { decimals: 15, withSi: true })
-      ).toEqual('123.456µ Unit');
+      ).toEqual('Unit 123.456µ');
     });
 
     it('formats 123,456,789,000 (decimals=12)', (): void => {
       expect(
         formatBalance(TESTVAL, { decimals: 12, withSi: true })
-      ).toEqual('123.456m Unit');
+      ).toEqual('Unit 123.456m');
     });
 
     it('formats 123,456,789,000 (decimals=9)', (): void => {
       expect(
         formatBalance(TESTVAL, { withSi: true }, 9)
-      ).toEqual('123.456 Unit');
+      ).toEqual('Unit 123.456');
     });
 
     it('formats 123,456,789,000 (decimals=9, no unit)', (): void => {
@@ -84,7 +84,7 @@ describe('formatBalance', (): void => {
     it('formats 123,456,789,000 (decimals=12, full SI)', (): void => {
       expect(
         formatBalance(TESTVAL, { withSiFull: true }, 12)
-      ).toEqual('123.456 milli Unit');
+      ).toEqual('Unit 123.456 milli');
     });
 
     it('formats 123,456,789,000 (decimals=12, full SI, no unit)', (): void => {
@@ -96,13 +96,13 @@ describe('formatBalance', (): void => {
     it('formats 123,456,789,000 (decimals=9, full SI)', (): void => {
       expect(
         formatBalance(TESTVAL, { withSiFull: true }, 9)
-      ).toEqual('123.456 Unit');
+      ).toEqual('Unit 123.456');
     });
 
     it('formats 123,456,789,000 (decimals=6)', (): void => {
       expect(
         formatBalance(TESTVAL, { withSi: true }, 6)
-      ).toEqual('123.456k Unit');
+      ).toEqual('Unit 123.456k');
     });
 
     it('formats 123,456,789,000 (decimals=6, unit specified)', (): void => {
@@ -114,25 +114,25 @@ describe('formatBalance', (): void => {
     it('formats 123,456,789,000 * 10 (decimals=12)', (): void => {
       expect(
         formatBalance(TESTVAL.muln(10), { withSi: true }, 12)
-      ).toEqual('1.234 Unit');
+      ).toEqual('Unit 1.234');
     });
 
     it('formats 123,456,789,000 * 100 (decimals=12)', (): void => {
       expect(
         formatBalance(TESTVAL.muln(100), { withSi: true }, 12)
-      ).toEqual('12.345 Unit');
+      ).toEqual('Unit 12.345');
     });
 
     it('formats 123,456,789,000 * 1000 (decimals=12)', (): void => {
       expect(
         formatBalance(TESTVAL.muln(1000), { withSi: true }, 12)
-      ).toEqual('123.456 Unit');
+      ).toEqual('Unit 123.456');
     });
 
     it('formats -123,456,789,000 (decimals=15)', (): void => {
       expect(
         formatBalance(new BN('-123456789000'), { withSi: true }, 15)
-      ).toEqual('-123.456µ Unit');
+      ).toEqual('-Unit 123.456µ');
     });
   });
 
@@ -140,25 +140,25 @@ describe('formatBalance', (): void => {
     it('formats 123,456,789,000 (decimals=12, forceUnit=base)', (): void => {
       expect(
         formatBalance(TESTVAL, { forceUnit: '-' }, 12)
-      ).toEqual('0.123 Unit');
+      ).toEqual('Unit 0.123');
     });
 
     it('formats 123,456,789,000 (decimals=9, forceUnit=base)', (): void => {
       expect(
         formatBalance(TESTVAL, { forceUnit: '-' }, 9)
-      ).toEqual('123.456 Unit');
+      ).toEqual('Unit 123.456');
     });
 
     it('formats 123,456,789,000 (decimals=7, forceUnit=base)', (): void => {
       expect(
         formatBalance(TESTVAL, { forceUnit: '-' }, 7)
-      ).toEqual('12,345.678 Unit');
+      ).toEqual('Unit 12,345.678');
     });
 
     it('formats 123,456,789,000 (decimals=15, forceUnit=µ)', (): void => {
       expect(
         formatBalance(TESTVAL, { forceUnit: 'µ' }, 15)
-      ).toEqual('123.456µ Unit');
+      ).toEqual('Unit 123.456µ');
     });
   });
 
@@ -197,7 +197,7 @@ describe('formatBalance', (): void => {
 
       expect(
         formatBalance(TESTVAL)
-      ).toEqual('123.456m Unit');
+      ).toEqual('Unit 123.456m');
     });
 
     it('formats 123,456,789,000 (defaultUnit=TEST)', (): void => {

--- a/packages/util/src/format/formatBalance.ts
+++ b/packages/util/src/format/formatBalance.ts
@@ -72,12 +72,12 @@ function _formatBalance <ExtToBn extends ToBn> (input?: number | string | BN | B
   const units = withSi || withSiFull
     ? si.value === '-'
       ? withUnit
-        ? ` ${isBoolean(withUnit) ? si.text : withUnit}`
+        ? `${isBoolean(withUnit) ? si.text : withUnit} `
         : ''
-      : `${withSiFull ? ` ${si.text}` : si.value}${withUnit ? ` ${isBoolean(withUnit) ? SI[SI_MID].text : withUnit}` : ''}`
+      : `${withSiFull ? ` ${si.text}` : si.value}${withUnit ? `${isBoolean(withUnit) ? SI[SI_MID].text : withUnit} ` : ''}`
     : '';
 
-  return `${isNegative ? '-' : ''}${formatDecimal(prefix || '0')}.${postfix}${units}`;
+  return `${isNegative ? '-' : ''}${units}${formatDecimal(prefix || '0')}.${postfix}`;
 }
 
 const formatBalance = _formatBalance as BalanceFormatter;


### PR DESCRIPTION
**Purely subjective PR**

As far as I can tell the [international number format](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) has the symbol as prefix instead of postfix. They also mention something in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217#Position_of_ISO_4217_code_in_amounts) on this but also state that it depends on country. Think it would be nice to go with English international convention and thought would create this PR.

```js
console.log(new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'EUR' }).format(number));
console.log(new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'USD' }).format(number));
console.log(new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'CHF' }).format(number));

// Outputs: 
// "€1,23,456.79"
// "US$1,23,456.79"
// "CHF 1,23,456.79"
```

I tried to adjust the specs but did not run any tests.