### PR TITLE
[FIX] Adjust error message

### DIFF
--- a/packages/util-crypto/src/key/extractSuri.spec.ts
+++ b/packages/util-crypto/src/key/extractSuri.spec.ts
@@ -8,7 +8,7 @@ describe('keyExtractSuri', (): void => {
   it('does not extract from invalid suri', (): void => {
     expect(
       (): ExtractResult => keyExtractSuri('//2')
-    ).toThrow(/to a secret URI/);
+    ).toThrow('Unable to match provided value to a secret URI');
   });
 
   it('derives on "hello world"', (): void => {

--- a/packages/util-crypto/src/key/extractSuri.ts
+++ b/packages/util-crypto/src/key/extractSuri.ts
@@ -22,7 +22,7 @@ export default function keyExtract (suri: string): ExtractResult {
   // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
   const matches = suri.match(RE_CAPTURE);
 
-  assert(!isNull(matches), `Unable to match '${suri}' to a secret URI`);
+  assert(!isNull(matches), 'Unable to match provided value to a secret URI');
 
   const [, phrase, , derivePath, , , password] = matches as string[];
   const { path } = keyExtractPath(derivePath);


### PR DESCRIPTION
I ran into a case where the secret value provided had trailing
whitespace, and when the code ran, it logged that secret value as part
of the stack trace.

This change will make it harder for users to accidentally leak key
material.