### PR TITLE
Ethereum keypair support

### DIFF
--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -22,9 +22,7 @@ const SIG_TYPE_NONE = new Uint8Array();
 const SIG_TYPE_ED25519 = new Uint8Array([0]);
 const SIG_TYPE_SR25519 = new Uint8Array([1]);
 const SIG_TYPE_ECDSA = new Uint8Array([2]);
-
-// FIXME This needs a mapping to supported - maybe ecdsa for MultiSignature?
-const SIG_TYPE_ETHEREUM = new Uint8Array([255]);
+const SIG_TYPE_ETHEREUM = SIG_TYPE_ECDSA;
 
 function isEmpty (u8a: Uint8Array): boolean {
   return u8a.reduce((count, u8): number => count + u8, 0) === 0;
@@ -69,7 +67,7 @@ function sign (type: KeypairType, message: Uint8Array, pair: Partial<Keypair>, {
 
 function verify (type: KeypairType, message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array): boolean {
   return {
-    ecdsa: (): boolean => secp256k1Verify(message, signature, blake2AsU8a(publicKey, 256), 'blake2'),
+    ecdsa: (): boolean => secp256k1Verify(message, signature, blake2AsU8a(publicKey), 'blake2'),
     ed25519: (): boolean => naclVerify(message, signature, publicKey),
     ethereum: (): boolean => secp256k1Verify(message, signature, keccakAsU8a(publicKey), 'keccak'),
     sr25519: (): boolean => schnorrkelVerify(message, signature, publicKey)
@@ -78,7 +76,7 @@ function verify (type: KeypairType, message: Uint8Array, signature: Uint8Array, 
 
 function getAddress (type: KeypairType, publicKey: Uint8Array): Uint8Array {
   if (type === 'ecdsa' && publicKey.length > 32) {
-    return blake2AsU8a(publicKey, 256);
+    return blake2AsU8a(publicKey);
   } else if (type === 'ethereum' && publicKey.length > 32) {
     return keccakAsU8a(publicKey);
   } else {

--- a/packages/util-crypto/src/ethereum/encode.ts
+++ b/packages/util-crypto/src/ethereum/encode.ts
@@ -12,13 +12,13 @@ export default function ethereumEncode (_address?: string | Uint8Array): string 
     return '0x';
   }
 
-  const address = u8aToHex(u8aToU8a(_address), -1, false).toLowerCase();
+  const address = u8aToHex(u8aToU8a(_address), -1, false);
 
   if (!isEthereumAddress(`0x${address}`)) {
     return '0x';
   }
 
-  const hash = u8aToHex(keccakAsU8a(address.toLowerCase()), -1, false);
+  const hash = u8aToHex(keccakAsU8a(address), -1, false);
   let result = '';
 
   for (let index = 0; index < 40; index++) {

--- a/packages/util-crypto/src/key/fromPath.ts
+++ b/packages/util-crypto/src/key/fromPath.ts
@@ -12,6 +12,8 @@ import keyHdkdEcdsa from './hdkdEcdsa';
 const generators = {
   ecdsa: keyHdkdEcdsa,
   ed25519: keyHdkdEd15519,
+  // FIXME This is Substrate-compatible, not Ethereum-compatible
+  ethereum: keyHdkdEcdsa,
   sr25519: keyHdkdSr15519
 };
 

--- a/packages/util-crypto/src/secp256k1/hasher.ts
+++ b/packages/util-crypto/src/secp256k1/hasher.ts
@@ -4,20 +4,16 @@
 
 import { HashType } from './types';
 
-import { u8aToU8a } from '@polkadot/util';
-
 import { blake2AsU8a } from '../blake2';
 import { keccakAsU8a } from '../keccak';
 
 const HASH_TYPES = ['blake2', 'keccak'];
 
 export default function secp256k1Hasher (hashType: HashType, data: Uint8Array | string): Uint8Array {
-  const u8a = u8aToU8a(data);
-
   if (hashType === 'blake2') {
-    return blake2AsU8a(u8a);
+    return blake2AsU8a(data);
   } else if (hashType === 'keccak') {
-    return keccakAsU8a(u8a);
+    return keccakAsU8a(data);
   }
 
   throw new Error(`Unsupported secp256k1 hasher '${hashType as string}', expected one of ${HASH_TYPES.join(', ')}`);

--- a/packages/util-crypto/src/secp256k1/hasher.ts
+++ b/packages/util-crypto/src/secp256k1/hasher.ts
@@ -11,7 +11,7 @@ const HASH_TYPES = ['blake2', 'keccak'];
 
 export default function secp256k1Hasher (hashType: HashType, data: Uint8Array | string): Uint8Array {
   if (hashType === 'blake2') {
-    return blake2AsU8a(data, 256);
+    return blake2AsU8a(data);
   } else if (hashType === 'keccak') {
     return keccakAsU8a(data);
   }

--- a/packages/util-crypto/src/secp256k1/hasher.ts
+++ b/packages/util-crypto/src/secp256k1/hasher.ts
@@ -4,16 +4,20 @@
 
 import { HashType } from './types';
 
+import { u8aToU8a } from '@polkadot/util';
+
 import { blake2AsU8a } from '../blake2';
 import { keccakAsU8a } from '../keccak';
 
 const HASH_TYPES = ['blake2', 'keccak'];
 
 export default function secp256k1Hasher (hashType: HashType, data: Uint8Array | string): Uint8Array {
+  const u8a = u8aToU8a(data);
+
   if (hashType === 'blake2') {
-    return blake2AsU8a(data);
+    return blake2AsU8a(u8a);
   } else if (hashType === 'keccak') {
-    return keccakAsU8a(data);
+    return keccakAsU8a(u8a);
   }
 
   throw new Error(`Unsupported secp256k1 hasher '${hashType as string}', expected one of ${HASH_TYPES.join(', ')}`);

--- a/packages/util-crypto/src/secp256k1/keypair/fromSeed.ts
+++ b/packages/util-crypto/src/secp256k1/keypair/fromSeed.ts
@@ -5,7 +5,7 @@
 import { Keypair } from '../../types';
 
 import elliptic from 'elliptic';
-import { assert, hexToU8a } from '@polkadot/util';
+import { assert, bnToU8a } from '@polkadot/util';
 
 const EC = elliptic.ec;
 const ec = new EC('secp256k1');
@@ -20,7 +20,7 @@ export default function secp256k1KeypairFromSeed (seed: Uint8Array): Keypair {
   const key = ec.keyFromPrivate(seed);
 
   return {
-    publicKey: new Uint8Array(key.getPublic().encodeCompressed('array')),
-    secretKey: hexToU8a(`0x${key.getPrivate('hex')}`)
+    publicKey: new Uint8Array(key.getPublic().encodeCompressed()),
+    secretKey: bnToU8a(key.getPrivate(), { bitLength: 256, isLe: false })
   };
 }

--- a/packages/util-crypto/src/secp256k1/sign.ts
+++ b/packages/util-crypto/src/secp256k1/sign.ts
@@ -6,7 +6,7 @@ import { Keypair } from '../types';
 import { HashType } from './types';
 
 import elliptic from 'elliptic';
-import { assert, u8aConcat } from '@polkadot/util';
+import { assert, bnToU8a, u8aConcat } from '@polkadot/util';
 
 import hasher from './hasher';
 
@@ -22,9 +22,10 @@ export default function secp256k1Sign (message: Uint8Array | string, { secretKey
 
   const key = ec.keyFromPrivate(secretKey);
   const ecsig = key.sign(hasher(hashType, message));
-  const rParam = new Uint8Array(ecsig.r.toArray());
-  const sParam = new Uint8Array(ecsig.s.toArray());
-  const recoveryParam = Uint8Array.of(ecsig.recoveryParam || 0);
 
-  return u8aConcat(rParam, sParam, recoveryParam);
+  return u8aConcat(
+    bnToU8a(ecsig.r, { bitLength: 256, isLe: false }),
+    bnToU8a(ecsig.s, { bitLength: 256, isLe: false }),
+    new Uint8Array([ecsig.recoveryParam || 0])
+  );
 }

--- a/packages/util-crypto/src/secp256k1/signVerify.spec.ts
+++ b/packages/util-crypto/src/secp256k1/signVerify.spec.ts
@@ -27,7 +27,7 @@ describe('sign and verify', (): void => {
     expect(sign(MESSAGE, pair)).toHaveLength(65);
   });
 
-  it('can sign and verify a message by random key', (): void => {
+  it('signs/verifies a message by random key', (): void => {
     const pair = pairFromSeed(randomAsU8a());
     const signature = sign(MESSAGE, pair);
     const address = hasher('blake2', pair.publicKey);
@@ -35,7 +35,7 @@ describe('sign and verify', (): void => {
     expect(verify(MESSAGE, signature, address)).toBe(true);
   });
 
-  it('can sign and verify a message by random key (keccak)', (): void => {
+  it('signs/verifies a message by random key (keccak)', (): void => {
     const pair = pairFromSeed(randomAsU8a());
     const signature = sign(MESSAGE, pair, 'keccak');
     const address = hasher('keccak', pair.publicKey);
@@ -43,7 +43,7 @@ describe('sign and verify', (): void => {
     expect(verify(MESSAGE, signature, address, 'keccak')).toBe(true);
   });
 
-  it('can fals verification on hasher mismatches', (): void => {
+  it('fails verification on hasher mismatches', (): void => {
     const pair = pairFromSeed(randomAsU8a());
     const signature = sign(MESSAGE, pair, 'keccak');
     const address = hasher('keccak', pair.publicKey);

--- a/packages/util-crypto/src/secp256k1/signVerify.spec.ts
+++ b/packages/util-crypto/src/secp256k1/signVerify.spec.ts
@@ -27,7 +27,7 @@ describe('sign and verify', (): void => {
     expect(sign(MESSAGE, pair)).toHaveLength(65);
   });
 
-  it('signs/verifies a message by random key', (): void => {
+  it('signs/verifies a message by random key (blake2)', (): void => {
     const pair = pairFromSeed(randomAsU8a());
     const signature = sign(MESSAGE, pair);
     const address = hasher('blake2', pair.publicKey);
@@ -50,4 +50,30 @@ describe('sign and verify', (): void => {
 
     expect(verify(MESSAGE, signature, address, 'blake2')).toBe(false);
   });
+
+  it('works over a range of random keys (blake2)', (): void => {
+    for (let i = 0; i < 1000; i++) {
+      const pair = pairFromSeed(randomAsU8a());
+
+      try {
+        expect(verify(MESSAGE, sign(MESSAGE, pair, 'blake2'), hasher('blake2', pair.publicKey), 'blake2')).toBe(true);
+      } catch (error) {
+        console.error(`blake2 failed on #${i}`);
+        throw error;
+      }
+    }
+  }, 120000);
+
+  it('works over a range of random keys (keccak)', (): void => {
+    for (let i = 0; i < 1000; i++) {
+      const pair = pairFromSeed(randomAsU8a());
+
+      try {
+        expect(verify(MESSAGE, sign(MESSAGE, pair, 'keccak'), hasher('keccak', pair.publicKey), 'keccak')).toBe(true);
+      } catch (error) {
+        console.error(`keccak failed on #${i}`);
+        throw error;
+      }
+    }
+  }, 120000);
 });

--- a/packages/util-crypto/src/secp256k1/signVerify.spec.ts
+++ b/packages/util-crypto/src/secp256k1/signVerify.spec.ts
@@ -52,7 +52,7 @@ describe('sign and verify', (): void => {
   });
 
   it('works over a range of random keys (blake2)', (): void => {
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 256; i++) {
       const pair = pairFromSeed(randomAsU8a());
 
       try {
@@ -65,7 +65,7 @@ describe('sign and verify', (): void => {
   }, 120000);
 
   it('works over a range of random keys (keccak)', (): void => {
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 256; i++) {
       const pair = pairFromSeed(randomAsU8a());
 
       try {

--- a/packages/util-crypto/src/secp256k1/verify.ts
+++ b/packages/util-crypto/src/secp256k1/verify.ts
@@ -5,7 +5,7 @@
 import { HashType } from './types';
 
 import elliptic from 'elliptic';
-import { u8aToU8a } from '@polkadot/util';
+import { assert, u8aToU8a } from '@polkadot/util';
 
 import hasher from './hasher';
 
@@ -18,6 +18,9 @@ const ec = new EC('secp256k1');
  */
 export default function secp256k1Verify (message: Uint8Array | string, signature: Uint8Array | string, address: Uint8Array | string, hashType: HashType = 'blake2'): boolean {
   const signatureU8a = u8aToU8a(signature);
+
+  assert(signatureU8a.length === 65, `Expected signature with 65 bytes, ${signatureU8a.length} found instead`);
+
   const sig = {
     r: signatureU8a.slice(0, 32),
     s: signatureU8a.slice(32, 64)
@@ -26,7 +29,7 @@ export default function secp256k1Verify (message: Uint8Array | string, signature
   const publicKey = new Uint8Array(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
     ec.recoverPubKey(hasher(hashType, message), sig, recovery)
-      .encodeCompressed(null)
+      .encodeCompressed()
   );
 
   return Buffer.compare(hasher(hashType, publicKey), u8aToU8a(address)) === 0;

--- a/packages/util-crypto/src/types.ts
+++ b/packages/util-crypto/src/types.ts
@@ -12,7 +12,7 @@ export interface Seedpair {
   seed: Uint8Array;
 }
 
-export type KeypairType = 'ed25519' | 'sr25519' | 'ecdsa';
+export type KeypairType = 'ed25519' | 'sr25519' | 'ecdsa' | 'ethereum';
 
 export interface VerifyResult {
   crypto: 'none' | KeypairType;


### PR DESCRIPTION
Part of https://github.com/polkadot-js/common/issues/656

Sadly this is where things starts going off-the-rails -

- MultiSignature doesn't have a specific Ethereum byte (Potentially same as normal ecdsa?)
- Not sure about the publicKey hashing
- the actual generated pairs from the same seed is non-Ethereum compatible