### PR TITLE
Fix `Error: @polkadot/wasm-crypto has not been initialized`

### DIFF
--- a/packages/util-crypto/src/schnorrkel/deriveHard.ts
+++ b/packages/util-crypto/src/schnorrkel/deriveHard.ts
@@ -6,12 +6,13 @@ import { Keypair } from '../types';
 
 import '../polyfill';
 
-import { sr25519DeriveKeypairHard } from '@polkadot/wasm-crypto';
+import { sr25519DeriveKeypairHard, waitReady } from '@polkadot/wasm-crypto';
 
 import keypairFromU8a from './keypair/fromU8a';
 import keypairToU8a from './keypair/toU8a';
 
-export default function deriveHard (keypair: Keypair, chainCode: Uint8Array): Keypair {
+export default async function deriveHard (keypair: Keypair, chainCode: Uint8Array): Keypair {
+  await waitReady()
   return keypairFromU8a(
     sr25519DeriveKeypairHard(keypairToU8a(keypair), chainCode)
   );

--- a/packages/util-crypto/src/schnorrkel/derivePublic.ts
+++ b/packages/util-crypto/src/schnorrkel/derivePublic.ts
@@ -4,8 +4,9 @@
 
 import '../polyfill';
 
-import { sr25519DerivePublicSoft } from '@polkadot/wasm-crypto';
+import { sr25519DerivePublicSoft, waitReady } from '@polkadot/wasm-crypto';
 
-export default function deriveSoft (publicKey: Uint8Array, chainCode: Uint8Array): Uint8Array {
+export default async function deriveSoft (publicKey: Uint8Array, chainCode: Uint8Array): Uint8Array {
+  await waitReady()
   return sr25519DerivePublicSoft(publicKey, chainCode);
 }

--- a/packages/util-crypto/src/schnorrkel/deriveSoft.ts
+++ b/packages/util-crypto/src/schnorrkel/deriveSoft.ts
@@ -6,12 +6,13 @@ import { Keypair } from '../types';
 
 import '../polyfill';
 
-import { sr25519DeriveKeypairSoft } from '@polkadot/wasm-crypto';
+import { sr25519DeriveKeypairSoft, waitReady } from '@polkadot/wasm-crypto';
 
 import keypairFromU8a from './keypair/fromU8a';
 import keypairToU8a from './keypair/toU8a';
 
-export default function deriveSoft (keypair: Keypair, chainCode: Uint8Array): Keypair {
+export default async function deriveSoft (keypair: Keypair, chainCode: Uint8Array): Keypair {
+  await waitReady()
   return keypairFromU8a(
     sr25519DeriveKeypairSoft(keypairToU8a(keypair), chainCode)
   );

--- a/packages/util-crypto/src/schnorrkel/keypair/fromSeed.ts
+++ b/packages/util-crypto/src/schnorrkel/keypair/fromSeed.ts
@@ -14,7 +14,7 @@ import keypairFromU8a from './fromU8a';
  * @name schnorrkelKeypairFromSeed
  * @description Returns a object containing a `publicKey` & `secretKey` generated from the supplied seed.
  */
-export default function schnorrkelKeypairFromSeed (seed: Uint8Array): Keypair {
+export default async function schnorrkelKeypairFromSeed (seed: Uint8Array): Keypair {
   await waitReady()
   return keypairFromU8a(
     sr25519KeypairFromSeed(seed)

--- a/packages/util-crypto/src/schnorrkel/keypair/fromSeed.ts
+++ b/packages/util-crypto/src/schnorrkel/keypair/fromSeed.ts
@@ -6,7 +6,7 @@ import { Keypair } from '../../types';
 
 import '../../polyfill';
 
-import { sr25519KeypairFromSeed } from '@polkadot/wasm-crypto';
+import { sr25519KeypairFromSeed, waitReady } from '@polkadot/wasm-crypto';
 
 import keypairFromU8a from './fromU8a';
 
@@ -15,6 +15,7 @@ import keypairFromU8a from './fromU8a';
  * @description Returns a object containing a `publicKey` & `secretKey` generated from the supplied seed.
  */
 export default function schnorrkelKeypairFromSeed (seed: Uint8Array): Keypair {
+  await waitReady()
   return keypairFromU8a(
     sr25519KeypairFromSeed(seed)
   );

--- a/packages/util-crypto/src/schnorrkel/sign.ts
+++ b/packages/util-crypto/src/schnorrkel/sign.ts
@@ -7,13 +7,15 @@ import { Keypair } from '../types';
 import '../polyfill';
 
 import { assert, u8aToU8a } from '@polkadot/util';
-import { sr25519Sign } from '@polkadot/wasm-crypto';
+import { sr25519Sign, waitReady } from '@polkadot/wasm-crypto';
 
 /**
  * @name schnorrkelSign
  * @description Returns message signature of `message`, using the supplied pair
  */
-export default function schnorrkelSign (message: Uint8Array | string, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
+export default async function schnorrkelSign (message: Uint8Array | string, { publicKey, secretKey }: Partial<Keypair>): Uint8Array {
+  await waitReady()
+
   assert(publicKey?.length === 32, 'Expected a valid publicKey, 32-bytes');
   assert(secretKey?.length === 64, 'Expected a valid secretKey, 64-bytes');
 

--- a/packages/util-crypto/src/schnorrkel/verify.ts
+++ b/packages/util-crypto/src/schnorrkel/verify.ts
@@ -5,13 +5,15 @@
 import '../polyfill';
 
 import { assert, u8aToU8a } from '@polkadot/util';
-import { sr25519Verify } from '@polkadot/wasm-crypto';
+import { sr25519Verify, waitReady } from '@polkadot/wasm-crypto';
 
 /**
  * @name schnorrkelVerify
  * @description Verifies the signature of `message`, using the supplied pair
  */
-export default function schnorrkelVerify (message: Uint8Array | string, signature: Uint8Array | string, publicKey: Uint8Array | string): boolean {
+export default async function schnorrkelVerify (message: Uint8Array | string, signature: Uint8Array | string, publicKey: Uint8Array | string): boolean {
+  await waitReady()
+  
   const messageU8a = u8aToU8a(message);
   const publicKeyU8a = u8aToU8a(publicKey);
   const signatureU8a = u8aToU8a(signature);


### PR DESCRIPTION
Fixes this error, related to @wasm-crypto not being initialized:

![image](https://user-images.githubusercontent.com/40721795/90638577-c97c6580-e22d-11ea-8073-523a09da9651.png)
