### PR TITLE
Add evmToAddress and addressToEvm crypto utils.

### DIFF
--- a/packages/util-crypto/src/address/addressToEvm.spec.ts
+++ b/packages/util-crypto/src/address/addressToEvm.spec.ts
@@ -1,0 +1,14 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { hexToU8a } from '@polkadot/util';
+
+import addressToEvm from './addressToEvm';
+
+describe('addressToEvm', (): void => {
+  it('creates a valid known EVM address', (): void => {
+    expect(
+      addressToEvm('KWCv1L3QX9LDPwY4VzvLmarEmXjVJidUzZcinvVnmxAJJCBou')
+    ).toEqual(hexToU8a('0x03b9dc646dd71118e5f7fda681ad9eca36eb3ee9'));
+  });
+});

--- a/packages/util-crypto/src/address/addressToEvm.ts
+++ b/packages/util-crypto/src/address/addressToEvm.ts
@@ -1,0 +1,14 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import decode from './decode';
+
+/**
+ * @name addressToEvm
+ * @summary Converts an SS58 address to its corresponding EVM address.
+ */
+export default function addressToEvm (address: string | Uint8Array, ignoreChecksum?: boolean): Uint8Array {
+  const decoded = decode(address, ignoreChecksum);
+
+  return decoded.subarray(0, 20);
+}

--- a/packages/util-crypto/src/address/evmToAddress.spec.ts
+++ b/packages/util-crypto/src/address/evmToAddress.spec.ts
@@ -1,0 +1,18 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import evmToAddress from './evmToAddress';
+
+describe('evmToAddress', (): void => {
+  it('creates a valid known SS58 address', (): void => {
+    expect(
+      evmToAddress('0xd43593c715fdd31c61141abd04a99fd6822c8558', 42, 'blake2')
+    ).toEqual('5FrLxJsyJ5x9n2rmxFwosFraxFCKcXZDngRLNectCn64UjtZ');
+  });
+
+  it('fails when length is invalid', (): void => {
+    expect(
+      () => evmToAddress('0x1234567890ABCDEF1234567890ABCDEF')
+    ).toThrow(/address length/);
+  });
+});

--- a/packages/util-crypto/src/address/evmToAddress.ts
+++ b/packages/util-crypto/src/address/evmToAddress.ts
@@ -1,0 +1,28 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import encode from './encode';
+import { Prefix } from './types';
+
+import hasher from '../secp256k1/hasher';
+import { HashType } from '../secp256k1/types';
+
+import { u8aConcat } from '@polkadot/util';
+
+/**
+ * @name evmToAddress
+ * @summary Converts an EVM address to its corresponding SS58 address.
+ */
+export default function evmToAddress (evmAddress: string | Uint8Array, ss58Format?: Prefix, hashType: HashType = 'blake2'): string {
+  const wrapError = (message: string) => `Converting ${evmAddress as string}: ${message}`;
+
+  const message = u8aConcat('evm:', evmAddress);
+
+  if (message.length !== 24) {
+    throw new Error(wrapError('Invalid evm address length'));
+  }
+
+  const address = hasher(hashType, message);
+
+  return encode(address, ss58Format);
+}

--- a/packages/util-crypto/src/address/index.ts
+++ b/packages/util-crypto/src/address/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2017-2020 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import addressToEvm from './addressToEvm';
 import checkAddress from './check';
 import checkAddressChecksum from './checkChecksum';
 import createKeyMulti from './keyMulti';
@@ -10,12 +11,14 @@ import deriveAddress from './derive';
 import encodeAddress from './encode';
 import encodeDerivedAddress from './encodeDerived';
 import encodeMultiAddress from './encodeMulti';
+import evmToAddress from './evmToAddress';
 import addressEq from './eq';
 import setSS58Format from './setSS58Format';
 import sortAddresses from './sort';
 
 export {
   addressEq,
+  addressToEvm,
   checkAddress,
   checkAddressChecksum,
   createKeyDerived,
@@ -25,6 +28,7 @@ export {
   encodeAddress,
   encodeDerivedAddress,
   encodeMultiAddress,
+  evmToAddress,
   setSS58Format,
   sortAddresses
 };


### PR DESCRIPTION
Adds two utils for manipulating EVM addresses.

* addressToEvm is based on logic here: https://github.com/paritytech/substrate/blob/frontier/frame/evm/src/lib.rs#L148 and truncates a Substrate public key to a 20-byte Ethereum key.
* evmToAddress is based on logic here: https://github.com/paritytech/substrate/blob/frontier/frame/evm/src/lib.rs#L169 and hashes a 20-byte Ethereum key to produce a 32-byte Substrate public key.