### PR TITLE
Add eth tests and truncate address for keccak

### DIFF
--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -5,7 +5,7 @@ import { Keypair, KeypairType } from '@polkadot/util-crypto/types';
 import { KeyringPair, KeyringPair$Json, KeyringPair$JsonEncodingTypes, KeyringPair$Meta, SignOptions } from '../types';
 import { PairInfo } from './types';
 
-import { assert, u8aConcat, u8aFixLength, u8aToHex } from '@polkadot/util';
+import { assert, u8aConcat, u8aToHex } from '@polkadot/util';
 import { blake2AsU8a, ethereumEncode, keccakAsU8a, keyExtractPath, keyFromPath, naclKeypairFromSeed as naclFromSeed, naclSign, schnorrkelKeypairFromSeed as schnorrkelFromSeed, schnorrkelSign, secp256k1Expand, secp256k1KeypairFromSeed as secp256k1FromSeed, secp256k1Sign, secp256k1Compress, signatureVerify } from '@polkadot/util-crypto';
 
 import { decodePair } from './decode';
@@ -178,7 +178,7 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
       return pairToJson(type, { address, meta }, recode(passphrase), !!passphrase);
     },
     verify: (message: Uint8Array, signature: Uint8Array): boolean =>
-      signatureVerify(message, signature, 
+      signatureVerify(message, signature,
         TYPE_ADDRESS[type](publicKey),
         type === 'ethereum').isValid
   };

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -5,7 +5,7 @@ import { Keypair, KeypairType } from '@polkadot/util-crypto/types';
 import { KeyringPair, KeyringPair$Json, KeyringPair$JsonEncodingTypes, KeyringPair$Meta, SignOptions } from '../types';
 import { PairInfo } from './types';
 
-import { assert, u8aConcat, u8aToHex } from '@polkadot/util';
+import { assert, u8aConcat, u8aFixLength, u8aToHex } from '@polkadot/util';
 import { blake2AsU8a, ethereumEncode, keccakAsU8a, keyExtractPath, keyFromPath, naclKeypairFromSeed as naclFromSeed, naclSign, schnorrkelKeypairFromSeed as schnorrkelFromSeed, schnorrkelSign, secp256k1Expand, secp256k1KeypairFromSeed as secp256k1FromSeed, secp256k1Sign, secp256k1Compress, signatureVerify } from '@polkadot/util-crypto';
 
 import { decodePair } from './decode';
@@ -178,6 +178,8 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
       return pairToJson(type, { address, meta }, recode(passphrase), !!passphrase);
     },
     verify: (message: Uint8Array, signature: Uint8Array): boolean =>
-      signatureVerify(message, signature, TYPE_ADDRESS[type](publicKey), type === 'ethereum').isValid
+      signatureVerify(message, signature, 
+        TYPE_ADDRESS[type](publicKey),
+        type === 'ethereum').isValid
   };
 }

--- a/packages/util-crypto/src/secp256k1/verify.ts
+++ b/packages/util-crypto/src/secp256k1/verify.ts
@@ -3,7 +3,7 @@
 
 import { HashType } from './types';
 
-import { assert, u8aEq, u8aToU8a } from '@polkadot/util';
+import { assert, u8aEq, u8aToU8a, u8aFixLength } from '@polkadot/util';
 
 import { secp256k1Expand } from './expand';
 import { secp256k1Hasher } from './hasher';
@@ -20,7 +20,6 @@ interface Options {
  */
 export function secp256k1Verify (message: Uint8Array | string, signature: Uint8Array | string, address: Uint8Array | string, { hashType = 'blake2', isExpanded = false }: Partial<Options> = {}): boolean {
   const u8a = u8aToU8a(signature);
-
   assert(u8a.length === 65, `Expected signature with 65 bytes, ${u8a.length} found instead`);
 
   const publicKey = new Uint8Array(
@@ -33,9 +32,17 @@ export function secp256k1Verify (message: Uint8Array | string, signature: Uint8A
       )
       .encodeCompressed()
   );
-
-  return u8aEq(
-    secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey),
-    u8aToU8a(address)
-  );
+  
+  if (hashType==="keccak"){
+    // ethereum addresses are truncated to 20 bytes (160bits)
+    return u8aEq(
+      u8aFixLength(secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey),160),
+      u8aFixLength(u8aToU8a(address),160)
+    );
+  } else { 
+    return u8aEq(
+      secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey),
+      u8aToU8a(address)
+    );
+  }
 }

--- a/packages/util-crypto/src/secp256k1/verify.ts
+++ b/packages/util-crypto/src/secp256k1/verify.ts
@@ -34,16 +34,16 @@ export function secp256k1Verify (message: Uint8Array | string, signature: Uint8A
       .encodeCompressed()
   );
 
-  if (hashType === 'keccak') {
-    // ethereum addresses are truncated to 20 bytes (160bits)
-    return u8aEq(
-      u8aFixLength(secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey), 160),
-      u8aFixLength(u8aToU8a(address), 160)
+  const signingAddress: Uint8Array = secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey);
+  const inputAddress: Uint8Array = u8aToU8a(address);
+
+  return hashType === 'keccak'
+    ? u8aEq(
+      u8aFixLength(signingAddress, 160),
+      u8aFixLength(inputAddress, 160)
+    )
+    : u8aEq(
+      signingAddress,
+      inputAddress
     );
-  } else {
-    return u8aEq(
-      secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey),
-      u8aToU8a(address)
-    );
-  }
 }

--- a/packages/util-crypto/src/secp256k1/verify.ts
+++ b/packages/util-crypto/src/secp256k1/verify.ts
@@ -20,6 +20,7 @@ interface Options {
  */
 export function secp256k1Verify (message: Uint8Array | string, signature: Uint8Array | string, address: Uint8Array | string, { hashType = 'blake2', isExpanded = false }: Partial<Options> = {}): boolean {
   const u8a = u8aToU8a(signature);
+
   assert(u8a.length === 65, `Expected signature with 65 bytes, ${u8a.length} found instead`);
 
   const publicKey = new Uint8Array(
@@ -32,14 +33,14 @@ export function secp256k1Verify (message: Uint8Array | string, signature: Uint8A
       )
       .encodeCompressed()
   );
-  
-  if (hashType==="keccak"){
+
+  if (hashType === 'keccak') {
     // ethereum addresses are truncated to 20 bytes (160bits)
     return u8aEq(
-      u8aFixLength(secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey),160),
-      u8aFixLength(u8aToU8a(address),160)
+      u8aFixLength(secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey), 160),
+      u8aFixLength(u8aToU8a(address), 160)
     );
-  } else { 
+  } else {
     return u8aEq(
       secp256k1Hasher(hashType, isExpanded ? secp256k1Expand(publicKey) : publicKey),
       u8aToU8a(address)

--- a/packages/util-crypto/src/signature/verify.spec.ts
+++ b/packages/util-crypto/src/signature/verify.spec.ts
@@ -10,10 +10,12 @@ import { signatureVerify } from '.';
 const ADDR_ED = 'DxN4uvzwPzJLtn17yew6jEffPhXQfdKHTp2brufb98vGbPN';
 const ADDR_SR = 'EK1bFgKm2FsghcttHT7TB7rNyXApFgs9fCbijMGQNyFGBQm';
 const ADDR_EC = 'XyFVXiGaHxoBhXZkSh6NS2rjFyVaVNUo5UiZDqZbuSfUdji';
+const ADDR_ETH = '0xe51153f44325ecf279f24bd51bfe412515a7c9ba';
 const MESSAGE = 'hello world';
 const SIG_ED = '0x299d3bf4c8bb51af732f8067b3a3015c0862a5ff34721749d8ed6577ea2708365d1c5f76bd519009971e41156f12c70abc2533837ceb3bad9a05a99ab923de06';
 const SIG_SR = '0xca01419b5a17219f7b78335658cab3b126db523a5df7be4bfc2bef76c2eb3b1dcf4ca86eb877d0a6cf6df12db5995c51d13b00e005d053b892bd09c594434288';
 const SIG_EC = '0x994638ee586d2c5dbd9bacacbc35d9b7e9018de8f7892f00c900db63bc57b1283e2ee7bc51a9b1c1dae121ac4f4b9e2a41cd1d6bf4bb3e24d7fed6faf6d85e0501';
+const SIG_ETH = '0x4e35aad35793b71f08566615661c9b741d7c605bc8935ac08608dff685324d71b5704fbd14c9297d2f584ea0735f015dcf0def66b802b3f555e1db916eda4b7700';
 const MUL_ED = u8aToHex(u8aConcat(new Uint8Array([0]), hexToU8a(SIG_ED)));
 const MUL_SR = u8aToHex(u8aConcat(new Uint8Array([1]), hexToU8a(SIG_SR)));
 const MUL_EC = u8aToHex(u8aConcat(new Uint8Array([2]), hexToU8a(SIG_EC)));
@@ -41,6 +43,20 @@ describe('signatureVerify', (): void => {
       expect(signatureVerify(MESSAGE, SIG_EC, ADDR_EC)).toEqual({
         crypto: 'ecdsa',
         isValid: true
+      });
+    });
+
+    it('verifies an ethereum signature', (): void => {
+      expect(signatureVerify(MESSAGE, SIG_ETH, ADDR_ETH)).toEqual({
+        crypto: 'ethereum',
+        isValid: true
+      });
+    });
+
+    it('fails on invalid ethereum signature', (): void => {
+      expect(signatureVerify(MESSAGE, SIG_EC, ADDR_ETH)).toEqual({
+        crypto: 'none',
+        isValid: false
       });
     });
 


### PR DESCRIPTION
This PR will fix the verify function from crypto-util so that it can be used by the Verify component for ethereum addresses.

The problem was that the verify function expected a 36bytes address instead of the truncated 20bytes address used by ethereum.

I added two tests