### PR TITLE
Cleanup/simplify ETH signing

### DIFF
--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -34,9 +34,9 @@ const TYPE_PREFIX = {
 };
 
 const TYPE_SIGNATURE = {
-  ecdsa: (m: Uint8Array, p: Partial<Keypair>) => secp256k1Sign(m, p, { hashType: 'blake2' }),
+  ecdsa: (m: Uint8Array, p: Partial<Keypair>) => secp256k1Sign(m, p, 'blake2'),
   ed25519: naclSign,
-  ethereum: (m: Uint8Array, p: Partial<Keypair>) => secp256k1Sign(m, p, { hashType: 'keccak' }),
+  ethereum: (m: Uint8Array, p: Partial<Keypair>) => secp256k1Sign(m, p, 'keccak'),
   sr25519: schnorrkelSign
 };
 
@@ -178,8 +178,6 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
       return pairToJson(type, { address, meta }, recode(passphrase), !!passphrase);
     },
     verify: (message: Uint8Array, signature: Uint8Array): boolean =>
-      signatureVerify(message, signature,
-        TYPE_ADDRESS[type](publicKey),
-        type === 'ethereum').isValid
+      signatureVerify(message, signature, TYPE_ADDRESS[type](publicKey)).isValid
   };
 }

--- a/packages/util-crypto/src/secp256k1/sign.ts
+++ b/packages/util-crypto/src/secp256k1/sign.ts
@@ -9,15 +9,11 @@ import { assert, bnToU8a, u8aConcat } from '@polkadot/util';
 import { secp256k1Hasher } from './hasher';
 import { EXPAND_OPT, secp256k1 } from './secp256k1';
 
-interface Options {
-  hashType: HashType;
-}
-
 /**
  * @name secp256k1Sign
  * @description Returns message signature of `message`, using the supplied pair
  */
-export function secp256k1Sign (message: Uint8Array | string, { secretKey }: Partial<Keypair>, { hashType = 'blake2' }: Partial<Options> = {}): Uint8Array {
+export function secp256k1Sign (message: Uint8Array | string, { secretKey }: Partial<Keypair>, hashType: HashType = 'blake2'): Uint8Array {
   assert(secretKey?.length === 32, 'Expected valid secp256k1 secretKey, 32-bytes');
 
   const key = secp256k1.keyFromPrivate(secretKey);

--- a/packages/util-crypto/src/secp256k1/signVerify.spec.ts
+++ b/packages/util-crypto/src/secp256k1/signVerify.spec.ts
@@ -4,10 +4,8 @@
 import { stringToU8a } from '@polkadot/util';
 
 import { randomAsU8a } from '../random/asU8a';
-import { secp256k1KeypairFromSeed } from './keypair/fromSeed';
 import { secp256k1Hasher } from './hasher';
-import { secp256k1Sign } from './sign';
-import { secp256k1Verify } from './verify';
+import { secp256k1Expand, secp256k1KeypairFromSeed, secp256k1Sign, secp256k1Verify } from '.';
 
 const MESSAGE = stringToU8a('this is a message');
 
@@ -36,18 +34,18 @@ describe('sign and verify', (): void => {
 
   it('signs/verifies a message by random key (keccak)', (): void => {
     const pair = secp256k1KeypairFromSeed(randomAsU8a());
-    const signature = secp256k1Sign(MESSAGE, pair, { hashType: 'keccak' });
-    const address = secp256k1Hasher('keccak', pair.publicKey);
+    const signature = secp256k1Sign(MESSAGE, pair, 'keccak');
+    const address = secp256k1Hasher('keccak', secp256k1Expand(pair.publicKey));
 
-    expect(secp256k1Verify(MESSAGE, signature, address, { hashType: 'keccak' })).toBe(true);
+    expect(secp256k1Verify(MESSAGE, signature, address, 'keccak')).toBe(true);
   });
 
   it('fails verification on hasher mismatches', (): void => {
     const pair = secp256k1KeypairFromSeed(randomAsU8a());
-    const signature = secp256k1Sign(MESSAGE, pair, { hashType: 'keccak' });
-    const address = secp256k1Hasher('keccak', pair.publicKey);
+    const signature = secp256k1Sign(MESSAGE, pair, 'keccak');
+    const address = secp256k1Hasher('keccak', secp256k1Expand(pair.publicKey));
 
-    expect(secp256k1Verify(MESSAGE, signature, address, { hashType: 'blake2' })).toBe(false);
+    expect(secp256k1Verify(MESSAGE, signature, address, 'blake2')).toBe(false);
   });
 
   it('works over a range of random keys (blake2)', (): void => {
@@ -56,7 +54,12 @@ describe('sign and verify', (): void => {
 
       try {
         expect(
-          secp256k1Verify(MESSAGE, secp256k1Sign(MESSAGE, pair, { hashType: 'blake2' }), secp256k1Hasher('blake2', pair.publicKey), { hashType: 'blake2' })
+          secp256k1Verify(
+            MESSAGE,
+            secp256k1Sign(MESSAGE, pair, 'blake2'),
+            secp256k1Hasher('blake2', pair.publicKey),
+            'blake2'
+          )
         ).toBe(true);
       } catch (error) {
         console.error(`blake2 failed on #${i}`);
@@ -70,7 +73,14 @@ describe('sign and verify', (): void => {
       const pair = secp256k1KeypairFromSeed(randomAsU8a());
 
       try {
-        expect(secp256k1Verify(MESSAGE, secp256k1Sign(MESSAGE, pair, { hashType: 'keccak' }), secp256k1Hasher('keccak', pair.publicKey), { hashType: 'keccak' })).toBe(true);
+        expect(
+          secp256k1Verify(
+            MESSAGE,
+            secp256k1Sign(MESSAGE, pair, 'keccak'),
+            secp256k1Hasher('keccak', secp256k1Expand(pair.publicKey)),
+            'keccak'
+          )
+        ).toBe(true);
       } catch (error) {
         console.error(`keccak failed on #${i}`);
         throw error;

--- a/packages/util-crypto/src/secp256k1/verify.spec.ts
+++ b/packages/util-crypto/src/secp256k1/verify.spec.ts
@@ -1,0 +1,19 @@
+// Copyright 2017-2020 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { secp256k1Verify } from '.';
+
+describe('secp256k1Verify', (): void => {
+  it('validates known ETH against address', (): void => {
+    const message = 'Pay KSMs to the Kusama account:88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee';
+
+    expect(
+      secp256k1Verify(
+        `\x19Ethereum Signed Message:\n${message.length.toString()}${message}`,
+        '0x55bd020bdbbdc02de34e915effc9b18a99002f4c29f64e22e8dcbb69e722ea6c28e1bb53b9484063fbbfd205e49dcc1f620929f520c9c4c3695150f05a28f52a01',
+        '0x002309df96687e44280bb72c3818358faeeb699c',
+        'keccak'
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/util-crypto/src/signature/verify.spec.ts
+++ b/packages/util-crypto/src/signature/verify.spec.ts
@@ -10,7 +10,7 @@ import { signatureVerify } from '.';
 const ADDR_ED = 'DxN4uvzwPzJLtn17yew6jEffPhXQfdKHTp2brufb98vGbPN';
 const ADDR_SR = 'EK1bFgKm2FsghcttHT7TB7rNyXApFgs9fCbijMGQNyFGBQm';
 const ADDR_EC = 'XyFVXiGaHxoBhXZkSh6NS2rjFyVaVNUo5UiZDqZbuSfUdji';
-const ADDR_ETH = '0x54dab85ee2c7b9f7421100d7134efb5dfa4239bf';
+const ADDR_ETH = '0x54Dab85EE2c7b9F7421100d7134eFb5DfA4239bF';
 const MESSAGE = 'hello world';
 const SIG_ED = '0x299d3bf4c8bb51af732f8067b3a3015c0862a5ff34721749d8ed6577ea2708365d1c5f76bd519009971e41156f12c70abc2533837ceb3bad9a05a99ab923de06';
 const SIG_SR = '0xca01419b5a17219f7b78335658cab3b126db523a5df7be4bfc2bef76c2eb3b1dcf4ca86eb877d0a6cf6df12db5995c51d13b00e005d053b892bd09c594434288';

--- a/packages/util-crypto/src/signature/verify.spec.ts
+++ b/packages/util-crypto/src/signature/verify.spec.ts
@@ -10,15 +10,16 @@ import { signatureVerify } from '.';
 const ADDR_ED = 'DxN4uvzwPzJLtn17yew6jEffPhXQfdKHTp2brufb98vGbPN';
 const ADDR_SR = 'EK1bFgKm2FsghcttHT7TB7rNyXApFgs9fCbijMGQNyFGBQm';
 const ADDR_EC = 'XyFVXiGaHxoBhXZkSh6NS2rjFyVaVNUo5UiZDqZbuSfUdji';
-const ADDR_ETH = '0x54Dab85EE2c7b9F7421100d7134eFb5DfA4239bF';
+const ADDR_ET = '0x54Dab85EE2c7b9F7421100d7134eFb5DfA4239bF';
 const MESSAGE = 'hello world';
 const SIG_ED = '0x299d3bf4c8bb51af732f8067b3a3015c0862a5ff34721749d8ed6577ea2708365d1c5f76bd519009971e41156f12c70abc2533837ceb3bad9a05a99ab923de06';
 const SIG_SR = '0xca01419b5a17219f7b78335658cab3b126db523a5df7be4bfc2bef76c2eb3b1dcf4ca86eb877d0a6cf6df12db5995c51d13b00e005d053b892bd09c594434288';
 const SIG_EC = '0x994638ee586d2c5dbd9bacacbc35d9b7e9018de8f7892f00c900db63bc57b1283e2ee7bc51a9b1c1dae121ac4f4b9e2a41cd1d6bf4bb3e24d7fed6faf6d85e0501';
-const SIG_ETH = '0x4e35aad35793b71f08566615661c9b741d7c605bc8935ac08608dff685324d71b5704fbd14c9297d2f584ea0735f015dcf0def66b802b3f555e1db916eda4b7700';
+const SIG_ET = '0x4e35aad35793b71f08566615661c9b741d7c605bc8935ac08608dff685324d71b5704fbd14c9297d2f584ea0735f015dcf0def66b802b3f555e1db916eda4b7700';
 const MUL_ED = u8aToHex(u8aConcat(new Uint8Array([0]), hexToU8a(SIG_ED)));
 const MUL_SR = u8aToHex(u8aConcat(new Uint8Array([1]), hexToU8a(SIG_SR)));
 const MUL_EC = u8aToHex(u8aConcat(new Uint8Array([2]), hexToU8a(SIG_EC)));
+const MUL_ET = u8aToHex(u8aConcat(new Uint8Array([2]), hexToU8a(SIG_ET)));
 
 describe('signatureVerify', (): void => {
   beforeEach(async (): Promise<void> => {
@@ -47,7 +48,7 @@ describe('signatureVerify', (): void => {
     });
 
     it('verifies an ethereum signature', (): void => {
-      expect(signatureVerify(MESSAGE, SIG_ETH, ADDR_ETH)).toEqual({
+      expect(signatureVerify(MESSAGE, SIG_ET, ADDR_ET)).toEqual({
         crypto: 'ethereum',
         isValid: true
       });
@@ -67,7 +68,7 @@ describe('signatureVerify', (): void => {
     });
 
     it('fails on invalid ethereum signature', (): void => {
-      expect(signatureVerify(MESSAGE, SIG_EC, ADDR_ETH)).toEqual({
+      expect(signatureVerify(MESSAGE, SIG_EC, ADDR_ET)).toEqual({
         crypto: 'none',
         isValid: false
       });
@@ -106,6 +107,13 @@ describe('signatureVerify', (): void => {
     it('verifies an ecdsa signature', (): void => {
       expect(signatureVerify(MESSAGE, MUL_EC, ADDR_EC)).toEqual({
         crypto: 'ecdsa',
+        isValid: true
+      });
+    });
+
+    it('verifies an ethereum signature', (): void => {
+      expect(signatureVerify(MESSAGE, MUL_ET, ADDR_ET)).toEqual({
+        crypto: 'ethereum',
         isValid: true
       });
     });

--- a/packages/util-crypto/src/signature/verify.spec.ts
+++ b/packages/util-crypto/src/signature/verify.spec.ts
@@ -10,7 +10,7 @@ import { signatureVerify } from '.';
 const ADDR_ED = 'DxN4uvzwPzJLtn17yew6jEffPhXQfdKHTp2brufb98vGbPN';
 const ADDR_SR = 'EK1bFgKm2FsghcttHT7TB7rNyXApFgs9fCbijMGQNyFGBQm';
 const ADDR_EC = 'XyFVXiGaHxoBhXZkSh6NS2rjFyVaVNUo5UiZDqZbuSfUdji';
-const ADDR_ETH = '0xe51153f44325ecf279f24bd51bfe412515a7c9ba';
+const ADDR_ETH = '0x54dab85ee2c7b9f7421100d7134efb5dfa4239bf';
 const MESSAGE = 'hello world';
 const SIG_ED = '0x299d3bf4c8bb51af732f8067b3a3015c0862a5ff34721749d8ed6577ea2708365d1c5f76bd519009971e41156f12c70abc2533837ceb3bad9a05a99ab923de06';
 const SIG_SR = '0xca01419b5a17219f7b78335658cab3b126db523a5df7be4bfc2bef76c2eb3b1dcf4ca86eb877d0a6cf6df12db5995c51d13b00e005d053b892bd09c594434288';
@@ -48,6 +48,19 @@ describe('signatureVerify', (): void => {
 
     it('verifies an ethereum signature', (): void => {
       expect(signatureVerify(MESSAGE, SIG_ETH, ADDR_ETH)).toEqual({
+        crypto: 'ethereum',
+        isValid: true
+      });
+    });
+
+    it('verifies an ethereum signature (known)', (): void => {
+      const message = 'Pay KSMs to the Kusama account:88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee';
+
+      expect(signatureVerify(
+        `\x19Ethereum Signed Message:\n${message.length.toString()}${message}`,
+        '0x55bd020bdbbdc02de34e915effc9b18a99002f4c29f64e22e8dcbb69e722ea6c28e1bb53b9484063fbbfd205e49dcc1f620929f520c9c4c3695150f05a28f52a01',
+        '0x002309df96687e44280bb72c3818358faeeb699c'
+      )).toEqual({
         crypto: 'ethereum',
         isValid: true
       });

--- a/packages/util-crypto/src/signature/verify.ts
+++ b/packages/util-crypto/src/signature/verify.ts
@@ -20,7 +20,7 @@ type Verifier = [KeypairType, (message: Uint8Array | string, signature: Uint8Arr
 
 const secp256k1VerifyHasher = (hashType: 'blake2' | 'keccak') =>
   (message: Uint8Array | string, signature: Uint8Array, publicKey: Uint8Array) =>
-    secp256k1Verify(message, signature, publicKey, { hashType });
+    secp256k1Verify(message, signature, publicKey, hashType);
 
 const VERIFIERS_ECDSA: Verifier[] = [
   ['ecdsa', secp256k1VerifyHasher('blake2')],

--- a/packages/util-crypto/src/signature/verify.ts
+++ b/packages/util-crypto/src/signature/verify.ts
@@ -16,11 +16,11 @@ interface VerifyInput {
   signature: Uint8Array;
 }
 
-type Verifier = [KeypairType, (message: Uint8Array | string, signature: Uint8Array, publicKey: Uint8Array, isExpanded?: boolean) => boolean];
+type Verifier = [KeypairType, (message: Uint8Array | string, signature: Uint8Array, publicKey: Uint8Array) => boolean];
 
 const secp256k1VerifyHasher = (hashType: 'blake2' | 'keccak') =>
-  (message: Uint8Array | string, signature: Uint8Array, publicKey: Uint8Array, isExpanded?: boolean) =>
-    secp256k1Verify(message, signature, publicKey, { hashType, isExpanded });
+  (message: Uint8Array | string, signature: Uint8Array, publicKey: Uint8Array) =>
+    secp256k1Verify(message, signature, publicKey, { hashType });
 
 const VERIFIERS_ECDSA: Verifier[] = [
   ['ecdsa', secp256k1VerifyHasher('blake2')],
@@ -35,10 +35,10 @@ const VERIFIERS: Verifier[] = [
 
 const CRYPTO_TYPES: ('ed25519' | 'sr25519' | 'ecdsa')[] = ['ed25519', 'sr25519', 'ecdsa'];
 
-function verifyDetect (result: VerifyResult, { message, publicKey, signature }: VerifyInput, isExpanded?: boolean, verifiers = VERIFIERS): VerifyResult {
+function verifyDetect (result: VerifyResult, { message, publicKey, signature }: VerifyInput, verifiers = VERIFIERS): VerifyResult {
   result.isValid = verifiers.some(([crypto, verify]): boolean => {
     try {
-      if (verify(message, signature, publicKey, isExpanded)) {
+      if (verify(message, signature, publicKey)) {
         result.crypto = crypto;
 
         return true;
@@ -53,7 +53,7 @@ function verifyDetect (result: VerifyResult, { message, publicKey, signature }: 
   return result;
 }
 
-function verifyMultisig (result: VerifyResult, { message, publicKey, signature }: VerifyInput, isExpanded?: boolean): VerifyResult {
+function verifyMultisig (result: VerifyResult, { message, publicKey, signature }: VerifyInput): VerifyResult {
   assert([0, 1, 2].includes(signature[0]), `Unknown crypto type, expected signature prefix [0..2], found ${signature[0]}`);
 
   const type = CRYPTO_TYPES[signature[0]] || 'none';
@@ -62,7 +62,7 @@ function verifyMultisig (result: VerifyResult, { message, publicKey, signature }
 
   try {
     result.isValid = {
-      ecdsa: () => verifyDetect(result, { message, publicKey, signature: signature.subarray(1) }, isExpanded, VERIFIERS_ECDSA).isValid,
+      ecdsa: () => verifyDetect(result, { message, publicKey, signature: signature.subarray(1) }, VERIFIERS_ECDSA).isValid,
       ed25519: () => naclVerify(message, signature.subarray(1), publicKey),
       none: () => { throw Error('no verify for `none` crypto type'); },
       sr25519: () => schnorrkelVerify(message, signature.subarray(1), publicKey)
@@ -74,7 +74,7 @@ function verifyMultisig (result: VerifyResult, { message, publicKey, signature }
   return result;
 }
 
-export function signatureVerify (message: Uint8Array | string, signature: Uint8Array | string, addressOrPublicKey: Uint8Array | string, isExpanded?: boolean): VerifyResult {
+export function signatureVerify (message: Uint8Array | string, signature: Uint8Array | string, addressOrPublicKey: Uint8Array | string): VerifyResult {
   const signatureU8a = u8aToU8a(signature);
 
   assert([64, 65, 66].includes(signatureU8a.length), `Invalid signature length, expected [64..66] bytes, found ${signatureU8a.length}`);
@@ -84,6 +84,6 @@ export function signatureVerify (message: Uint8Array | string, signature: Uint8A
   const input = { message, publicKey, signature: signatureU8a };
 
   return [0, 1, 2].includes(signatureU8a[0]) && [65, 66].includes(signatureU8a.length)
-    ? verifyMultisig(result, input, isExpanded)
-    : verifyDetect(result, input, isExpanded);
+    ? verifyMultisig(result, input)
+    : verifyDetect(result, input);
 }


### PR DESCRIPTION
Closes https://github.com/polkadot-js/common/issues/759

Always assumed that in keccak mode we are dealing with Ethereum addresses. Remove the expansion part (caller ensures address is correctly specified)