### PR TITLE
fix createPair for ethereum addresses

### DIFF
--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -112,11 +112,12 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
   };
 
   const encodeAddress = (): string => {
-    const raw = TYPE_ADDRESS[type](publicKey);
-
-    return type === 'ethereum'
-      ? ethereumEncode(raw)
-      : toSS58(raw);
+    if (type === 'ethereum' ){
+      return ethereumEncode(publicKey)
+    } else {
+      const raw = TYPE_ADDRESS[type](publicKey);
+      return toSS58(raw)
+    }
   };
 
   return {


### PR DESCRIPTION
in createPair, the TYPE_ADDRESS function for ethereum doesn't handle address properly