### PR TITLE
Allow for addition of raw pairs to the keyring

### DIFF
--- a/packages/keyring/src/keyring.ts
+++ b/packages/keyring/src/keyring.ts
@@ -121,6 +121,16 @@ export class Keyring implements KeyringInstance {
   }
 
   /**
+   * @name addFromPair
+   * @summary Stores an account created from an explicit publicKey/secreteKey combination
+   */
+  public addFromPair (pair: Keypair, meta: KeyringPair$Meta = {}, type: KeypairType = this.type): KeyringPair {
+    return this.addPair(
+      this.createFromPair(pair, meta, type)
+    );
+  }
+
+  /**
    * @name addFromSeed
    * @summary Stores an account, given seed data, as a Key/Value (public key, pair) in Keyring Pair Dictionary
    * @description Stores in a keyring pair dictionary the public key of the pair as a key and the pair as the associated value.
@@ -128,7 +138,9 @@ export class Keyring implements KeyringInstance {
    * `addPair` to store in a keyring pair dictionary the public key of the generated pair as a key and the pair as the associated value.
    */
   public addFromSeed (seed: Uint8Array, meta: KeyringPair$Meta = {}, type: KeypairType = this.type): KeyringPair {
-    return this.addPair(createPair({ toSS58: this.encodeAddress, type }, keypairFromSeed[type](seed), meta, null));
+    return this.addPair(
+      createPair({ toSS58: this.encodeAddress, type }, keypairFromSeed[type](seed), meta, null)
+    );
   }
 
   /**
@@ -167,6 +179,14 @@ export class Keyring implements KeyringInstance {
       : base64Decode(encoded);
 
     return createPair({ toSS58: this.encodeAddress, type: cryptoType as KeypairType }, { publicKey, secretKey: new Uint8Array() }, meta, decoded, encType);
+  }
+
+  /**
+   * @name createFromPair
+   * @summary Creates a pair from an explicit publicKey/secreteKey combination
+   */
+  public createFromPair (pair: Keypair, meta: KeyringPair$Meta = {}, type: KeypairType = this.type): KeyringPair {
+    return createPair({ toSS58: this.encodeAddress, type }, pair, meta, null);
   }
 
   /**

--- a/packages/keyring/src/pair/decode.ts
+++ b/packages/keyring/src/pair/decode.ts
@@ -4,7 +4,7 @@
 import type { EncryptedJsonEncoding } from '@polkadot/util-crypto/json/types';
 import type { PairInfo } from './types';
 
-import { assert, u8aEq } from '@polkadot/util';
+import { assert, isUndefined, u8aEq } from '@polkadot/util';
 import { jsonDecryptData } from '@polkadot/util-crypto';
 
 import { PKCS8_DIVIDER, PKCS8_HEADER, PUB_LENGTH, SEC_LENGTH, SEED_LENGTH } from './defaults';
@@ -15,7 +15,10 @@ type DecodeResult = PairInfo & {
   secretKey: Uint8Array;
 };
 
-export function decodePair (passphrase?: string, encrypted?: Uint8Array | null, encType?: EncryptedJsonEncoding[]): DecodeResult {
+export function decodePair (passphrase?: string, encrypted?: Uint8Array | null, _encType?: EncryptedJsonEncoding | EncryptedJsonEncoding[]): DecodeResult {
+  const encType = Array.isArray(_encType) || isUndefined(_encType)
+    ? _encType
+    : [_encType];
   const decrypted = jsonDecryptData(encrypted, passphrase, encType);
   const header = decrypted.subarray(0, PKCS8_HEADER.length);
 

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -3,7 +3,7 @@
 
 import type { Prefix } from '@polkadot/util-crypto/address/types';
 import type { EncryptedJson } from '@polkadot/util-crypto/json/types';
-import type { KeypairType } from '@polkadot/util-crypto/types';
+import type { Keypair, KeypairType } from '@polkadot/util-crypto/types';
 
 export interface KeyringOptions {
   ss58Format?: Prefix;
@@ -62,9 +62,11 @@ export interface KeyringInstance {
   addFromAddress (address: string | Uint8Array, meta?: KeyringPair$Meta, encoded?: Uint8Array | null, type?: KeypairType, ignoreChecksum?: boolean): KeyringPair;
   addFromJson (pair: KeyringPair$Json, ignoreChecksum?: boolean): KeyringPair;
   addFromMnemonic (mnemonic: string, meta?: KeyringPair$Meta, type?: KeypairType): KeyringPair;
+  addFromPair (pair: Keypair, meta?: KeyringPair$Meta, type?: KeypairType): KeyringPair
   addFromSeed (seed: Uint8Array, meta?: KeyringPair$Meta, type?: KeypairType): KeyringPair;
   addFromUri (suri: string, meta?: KeyringPair$Meta, type?: KeypairType): KeyringPair;
   createFromJson (json: KeyringPair$Json, ignoreChecksum?: boolean): KeyringPair;
+  createFromPair (pair: Keypair, meta: KeyringPair$Meta, type: KeypairType): KeyringPair
   createFromUri (suri: string, meta?: KeyringPair$Meta, type?: KeypairType): KeyringPair;
   getPair (address: string | Uint8Array): KeyringPair;
   getPairs (): KeyringPair[];


### PR DESCRIPTION
Something that came up in https://github.com/polkadot-js/common/issues/915#issuecomment-791218646 - it would be useful to allow the addition of raw public/secret pairs as to the keyring well (which actually encapsulates the createPair completely, i.e. no need to use it separately)