### PR TITLE
Extra check for process for browser bundles

### DIFF
--- a/packages/util/src/logger.ts
+++ b/packages/util/src/logger.ts
@@ -77,10 +77,10 @@ function noop (): void {
 }
 
 function parseEnv (type: string): [boolean, number] {
-  const maxSize = parseInt(process?.env?.DEBUG_MAX || '-1', 10);
+  const maxSize = parseInt((typeof process === 'object' ? process : {})?.env?.DEBUG_MAX || '-1', 10);
 
   return [
-    (process?.env?.DEBUG || '').toLowerCase().split(',').some((e) => !!e && (e === '*' || type.startsWith(e))),
+    ((typeof process === 'object' ? process : {})?.env?.DEBUG || '').toLowerCase().split(',').some((e) => !!e && (e === '*' || type.startsWith(e))),
     isNaN(maxSize) ? -1 : maxSize
   ];
 }


### PR DESCRIPTION
Webpack 5 now removed node shims, so when building for browser bundle external packages are recommended to either provide a `browser` field in `package.json` to point to umd package (which @polkadot.js/utils doesn't have) or add extra check for `process` 
https://webpack.js.org/migrate/5/

And unfortunately babel doesn't transpile optional chaining here correctly it seems as it still throws error that process is undefined 

`const maxSize = parseInt(((_process = process) === null || _process === void 0 ? void 0 : (_process$env = _process.env) === null || _process$env === void 0 ? void 0 : _process$env.DEBUG_MAX) || '-1', 10);`