### PR TITLE
logger - wildcard include/exclude with DEBUG env

### DIFF
--- a/packages/util/src/logger.spec.ts
+++ b/packages/util/src/logger.spec.ts
@@ -118,6 +118,8 @@ describe('logger', (): void => {
   });
 
   it('does debug log when DEBUG partial specified', (): void => {
+    process.env.DEBUG = 'test*';
+
     l = logger('testing');
     l.debug('test');
 
@@ -159,5 +161,32 @@ describe('logger', (): void => {
     ln.debug('test');
 
     expect(spy.log).not.toHaveBeenCalled();
+  });
+
+  it('does not debug log when explicitly excluded', (): void => {
+    process.env.DEBUG = '*,-test';
+
+    l = logger('test');
+    l.debug('test');
+
+    expect(spy.log).not.toHaveBeenCalled();
+  });
+
+  it('does not debug log when part of exclusion group', (): void => {
+    process.env.DEBUG = '*,-test:*';
+
+    l = logger('test:sub');
+    l.debug('test');
+
+    expect(spy.log).not.toHaveBeenCalled();
+  });
+
+  it('does debug log when not part of exclusion groups', (): void => {
+    process.env.DEBUG = '*,-test:*,-tes,-a:*';
+
+    l = logger('test');
+    l.debug('test');
+
+    expect(spy.log).toHaveBeenCalled();
   });
 });

--- a/packages/util/src/logger.ts
+++ b/packages/util/src/logger.ts
@@ -80,11 +80,23 @@ function parseEnv (type: string): [boolean, number] {
   const env = (typeof process === 'object' ? process : {}).env || {};
   const maxSize = parseInt(env.DEBUG_MAX || '-1', 10);
 
+  let isDebugOn = false;
+
+  (env.DEBUG || '')
+    .toLowerCase()
+    .split(',')
+    .forEach((e) => {
+      if (!!e && (e === '*' || type === e || (e.endsWith('*') && type.startsWith(e.slice(0, -1))))) {
+        isDebugOn = true;
+      }
+
+      if (!!e && e.startsWith('-') && (type === e.slice(1) || (e.endsWith('*') && type.startsWith(e.slice(1, -1))))) {
+        isDebugOn = false;
+      }
+    });
+
   return [
-    (env.DEBUG || '')
-      .toLowerCase()
-      .split(',')
-      .some((e) => !!e && (e === '*' || type.startsWith(e))),
+    isDebugOn,
     isNaN(maxSize)
       ? -1
       : maxSize


### PR DESCRIPTION
Projects that make use of https://www.npmjs.com/package/debug may rely on `DEBUG` env to specify a set debuggers to use, which may include wildcards and exclusion groups (https://www.npmjs.com/package/debug#wildcards), for example:
```
DEBUG=*,-api:*
```
_(use all debuggers **except** those that begin with `api:`)_
```
DEBUG=api:*
```
_(use all debuggers that begin with `api:`)_

Currently it's not possible to exclude loggers created by `@polkadot` packages or include only one of the loggers, whithout including all others that start with the same set of characters.

This PR is a suggestion of how this problem may be addressed.