### PR TITLE
Add additional 2-byte ss58 tests (verification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Added additional double-byte ss58 tests
+
+
 ## 6.3.1 Apr 25, 2021
 
 Changes:

--- a/packages/util-crypto/src/address/checksum.spec.ts
+++ b/packages/util-crypto/src/address/checksum.spec.ts
@@ -17,6 +17,18 @@ describe('checkAddressChecksum', (): void => {
     ).toEqual([true, 34, 2, 66]);
   });
 
+  it('correctly extracts the info from a 2-byte-prefix address (69)', (): void => {
+    expect(
+      checkAddressChecksum(base58Decode('cnVvyMzRdqjwejTFuByQQ4w2yu78V2hpFixjHQz5zr6NSYsxA'))
+    ).toEqual([true, 34, 2, 69]);
+  });
+
+  it('correctly extracts the info from a 2-byte-prefix address (252)', (): void => {
+    expect(
+      checkAddressChecksum(base58Decode('xw8Ffc2SZtDqUJKd9Ky4vc7PRz2D2asuVkEEzf3WGAbw9cnfq'))
+    ).toEqual([true, 34, 2, 252]);
+  });
+
   it('correctly extracts the info from a 2-byte-prefix address (255)', (): void => {
     expect(
       checkAddressChecksum(base58Decode('yGHU8YKprxHbHdEv7oUK4rzMZXtsdhcXVG2CAMyC9WhzhjH2k'))

--- a/packages/util-crypto/src/address/decode.spec.ts
+++ b/packages/util-crypto/src/address/decode.spec.ts
@@ -89,6 +89,22 @@ describe('decodeAddress', (): void => {
     );
   });
 
+  it('decodes a 2-byte prefix (69)', (): void => {
+    expect(
+      decodeAddress('cnUaoo5wodnTVA4bnr4woSweto8hWZADUvLFXkR9Q6U7BRsbF')
+    ).toEqual(
+      hexToU8a('0x88eafe0305d460d1695cf34c2f786050df8e40d215e488790cc70929c9e8316d')
+    );
+  });
+
+  it('decodes a 2-byte prefix (252)', (): void => {
+    expect(
+      decodeAddress('xw9Hca4RJTmBRgzJT4ieJBh7XCK9gE3NXBDSEmgGHd4TCrbnG')
+    ).toEqual(
+      hexToU8a('0xfc422da6c3bc6dfa2a436a506428072941662f816987baaa8914e02ff5947f4b')
+    );
+  });
+
   it('decodes a 2-byte prefix (255)', (): void => {
     expect(
       decodeAddress('yGHU8YKprxHbHdEv7oUK4rzMZXtsdhcXVG2CAMyC9WhzhjH2k')
@@ -101,12 +117,6 @@ describe('decodeAddress', (): void => {
     expect(
       u8aToHex(decodeAddress('4pbsSkWcBaYoFHrKJZp5fDVUKbqSYD9dhZZGvpp3vQ5ysVs5ybV'))
     ).toEqual('0x035676109c54b9a16d271abeb4954316a40a32bcce023ac14c8e26e958aa68fba9');
-  });
-
-  it.skip('allows invalid prefix (in list)', (): void => {
-    expect(
-      (): Uint8Array => decodeAddress('6GfvWUvHvU8otbZ7sFhXH4eYeMcKdUkL61P3nFy52efEPVUx')
-    ).toThrow(/address prefix/);
   });
 
   it('fails when length is invalid', (): void => {

--- a/packages/util-crypto/src/address/encode.spec.ts
+++ b/packages/util-crypto/src/address/encode.spec.ts
@@ -27,10 +27,22 @@ const SUBKEY = [
     ss58Format: 66
   },
   {
+    // sora
+    address: 'cnVRwXfAnz3RSVQyBUC8f8McrK3YBX2QYd4WoctpeSC6VTJYm',
+    publicKey: '0xae640d53cfa815f4a6a50ae70235cd7d9d134d0f1c3a4ccd118e321dfb6ab51f',
+    ss58Format: 69
+  },
+  {
     // ecdsa
     address: '4pbsSkWcBaYoFHrKJZp5fDVUKbqSYD9dhZZGvpp3vQ5ysVs5ybV',
     publicKey: '0x035676109c54b9a16d271abeb4954316a40a32bcce023ac14c8e26e958aa68fba9',
     ss58Format: 200
+  },
+  {
+    // social-network
+    address: 'xw5g1Eec8LT99pZLZMaTWwrwvNtfM6vrSuZeVbtEszCDUwByg',
+    publicKey: '0x5c64f1151f0ce4358c27238fb20c88e7c899825436f565410724c8c2c5add869',
+    ss58Format: 252
   },
   {
     address: 'yGF4JP7q5AK46d1FPCEm9sYQ4KooSjHMpyVAjLnsCSWVafPnf',


### PR DESCRIPTION
Sanity checks for https://github.com/polkadot-js/common/issues/962

All fine, so not an ss58 issue on the encoders