### PR TITLE
docs: fix typo in naclSeal docs.

### DIFF
--- a/packages/util-crypto/src/nacl/seal.ts
+++ b/packages/util-crypto/src/nacl/seal.ts
@@ -19,7 +19,7 @@ interface Sealed {
  * <BR>
  *
  * ```javascript
- * import { naclEncrypt } from '@polkadot/util-crypto';
+ * import { naclSeal } from '@polkadot/util-crypto';
  *
  * naclSeal([...], [...], [...], [...]); // => [...]
  * ```


### PR DESCRIPTION
Was using naclSeal and noticed a wrong import in the docs. Thought might change it to remove confusion.