### PR TITLE
Add Edgeware ledger app

### DIFF
--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -4,13 +4,14 @@
 import type Transport from '@ledgerhq/hw-transport';
 import type { SubstrateApp } from '@zondax/ledger-polkadot';
 
-import { newDockApp, newEquilibriumApp, newKusamaApp, newPolkadotApp, newPolymeshApp } from '@zondax/ledger-polkadot';
+import { newDockApp, newEdgewareApp, newEquilibriumApp, newKusamaApp, newPolkadotApp, newPolymeshApp } from '@zondax/ledger-polkadot';
 
 // These match up with the network keys in the @polkadot/networks package
 // (which is turn aligns with the substrate/ss58-registry.json as the single
 // source of truth)
 export const ledgerApps: Record<string, (transport: Transport) => SubstrateApp> = {
   'dock-mainnet': newDockApp,
+  edgeware: newEdgewareApp,
   equilibrium: newEquilibriumApp,
   kusama: newKusamaApp,
   polkadot: newPolkadotApp,

--- a/packages/networks/src/defaults.ts
+++ b/packages/networks/src/defaults.ts
@@ -54,6 +54,7 @@ export const knownIcon: KnownIcon = {
 // support for ledger
 export const knownLedger: KnownLedger = {
   'dock-mainnet': 0x00000252,
+  edgeware: 0x0000020b,
   equilibrium: 0x05f5e0fd,
   kusama: 0x000001b2,
   polkadot: 0x00000162,


### PR DESCRIPTION
Adds Ledger support for Edgeware, which should be supported by the Zondax library as of https://github.com/Zondax/ledger-substrate-js/pull/35.