### PR TITLE
Compute HDKD within function(s)

### DIFF
--- a/packages/util-crypto/src/nacl/deriveHard.ts
+++ b/packages/util-crypto/src/nacl/deriveHard.ts
@@ -5,9 +5,9 @@ import { compactAddLength, stringToU8a, u8aConcat } from '@polkadot/util';
 
 import { blake2AsU8a } from '../blake2/asU8a';
 
-const HDKD = compactAddLength(stringToU8a('Ed25519HDKD'));
-
 export function naclDeriveHard (seed: Uint8Array, chainCode: Uint8Array): Uint8Array {
+  const HDKD = compactAddLength(stringToU8a('Ed25519HDKD'));
+
   return blake2AsU8a(
     u8aConcat(HDKD, seed, chainCode)
   );

--- a/packages/util-crypto/src/secp256k1/deriveHard.ts
+++ b/packages/util-crypto/src/secp256k1/deriveHard.ts
@@ -5,9 +5,9 @@ import { compactAddLength, stringToU8a, u8aConcat } from '@polkadot/util';
 
 import { blake2AsU8a } from '../blake2/asU8a';
 
-const HDKD = compactAddLength(stringToU8a('Secp256k1HDKD'));
-
 export function secp256k1DeriveHard (seed: Uint8Array, chainCode: Uint8Array): Uint8Array {
+  const HDKD = compactAddLength(stringToU8a('Secp256k1HDKD'));
+
   // NOTE This is specific to the Substrate HDD derivation, so always use the blake2 hasher
   return blake2AsU8a(u8aConcat(HDKD, seed, chainCode), 256);
 }


### PR DESCRIPTION
Small adjustment to compute HDKD const(s) within relevant deriveHard functions instead of at file level. This is to correct an issue found running Jest jsdom tests for canvas-ui.

https://github.com/paritytech/canvas-ui-v2/pull/22#issuecomment-858814917