### PR TITLE
Extending Substrate network registry with `Heiko` and `Parallel`

### DIFF
--- a/packages/networks/src/substrate.ts
+++ b/packages/networks/src/substrate.ts
@@ -577,5 +577,23 @@ export const knownSubstrate: KnownSubstrate[] = [
     standardAccount: '*25519',
     symbols: ['BSX'],
     website: 'https://bsx.fi'
+  },
+  {
+    decimals: [12],
+    displayName: 'Heiko',
+    network: 'heiko',
+    prefix: 110,
+    standardAccount: '*25519',
+    symbols: ['HKO'],
+    website: 'https://parallel.fi/'
+  },
+  {
+    decimals: [12],
+    displayName: 'Parallel',
+    network: 'parallel',
+    prefix: 172,
+    standardAccount: '*25519',
+    symbols: ['PARA'],
+    website: 'https://parallel.fi/'
   }
 ];


### PR DESCRIPTION
Resolves #1046

Copied from the registry networks listed in https://github.com/polkadot-js/common/blob/master/packages/networks/src/substrate.ts

@tomusdrw not sure who to add as the reviewer here 