### PR TITLE
Add in ability to encrypt/decrypt msg with keyring

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@babel/core": "^7.14.8",
     "@polkadot/dev": "^0.62.57",
     "@polkadot/ts": "^0.4.4",
+    "@types/ed2curve": "^0.2.2",
     "@types/jest": "^26.0.24"
   },
   "version": "7.0.3"

--- a/packages/keyring/src/pair/index.spec.ts
+++ b/packages/keyring/src/pair/index.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { hexToU8a, u8aToHex } from '@polkadot/util';
-import { cryptoWaitReady, encodeAddress as toSS58, setSS58Format } from '@polkadot/util-crypto';
+import { cryptoWaitReady, encodeAddress as toSS58, setSS58Format} from '@polkadot/util-crypto';
 
 import { PAIRSSR25519 } from '../testing';
 import { createTestPairs } from '../testingPairs';
@@ -18,6 +18,10 @@ describe('pair', (): void => {
   });
 
   const SIGNATURE = new Uint8Array([80, 191, 198, 147, 225, 207, 75, 88, 126, 39, 129, 109, 191, 38, 72, 181, 75, 254, 81, 143, 244, 79, 237, 38, 236, 141, 28, 252, 134, 26, 169, 234, 79, 33, 153, 158, 151, 34, 175, 188, 235, 20, 35, 135, 83, 120, 139, 211, 233, 130, 1, 208, 201, 215, 73, 80, 56, 98, 185, 196, 11, 8, 193, 14]);
+  const ENCRYPTED = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 132, 59, 53, 85, 227, 40, 107, 48, 234, 198, 238, 157, 238, 224, 235, 179, 75, 153, 241, 142, 254]);
+  
+  // the last byte is changed from 254 -> 253
+  const ENCRYPTED_CHANGED = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 132, 59, 53, 85, 227, 40, 107, 48, 234, 198, 238, 157, 238, 224, 235, 179, 75, 153, 241, 142, 253]);
 
   it('has a publicKey', (): void => {
     expect(
@@ -53,7 +57,7 @@ describe('pair', (): void => {
   it('fails a correctly signed message (signer changed)', (): void => {
     expect(
       keyring.alice.verify(
-        new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65]),
+        new Uint8Array([0x61, 0x62, 0x63, 0x64]),
         SIGNATURE,
         keyring.bob.publicKey
       )
@@ -92,6 +96,55 @@ describe('pair', (): void => {
         keyring.bob.publicKey
       )
     ).toBe(false);
+  });
+
+  it('allows encrypting', (): void => {
+    const message = new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65]);
+    expect(
+      keyring.alice.encryptMessage(
+        message,
+        keyring.bob.publicKey,
+        new Uint8Array(24)
+      )
+    ).toEqual(ENCRYPTED)
+  });
+
+  it('validates a correctly encrypted message', (): void => {
+    const message = new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65]);
+
+    expect(
+      keyring.bob.decryptMessage(
+        ENCRYPTED,
+        keyring.alice.publicKey
+      )
+    ).toEqual(message);
+  });
+
+  it('fails a correctly encrypted message (message changed)', (): void => {
+    expect(
+      keyring.bob.decryptMessage(
+        ENCRYPTED_CHANGED,
+        keyring.alice.publicKey
+      )
+    ).toEqual(null);
+  });
+
+  it('fails a correctly encrypted message (sender changed)', (): void => {
+    expect(
+      keyring.bob.decryptMessage(
+        ENCRYPTED,
+        keyring.charlie.publicKey
+      )
+    ).toEqual(null);
+  });
+
+  it('fails a correctly encrypted message (receiver changed)', (): void => {
+    expect(
+      keyring.charlie.decryptMessage(
+        ENCRYPTED,
+        keyring.alice.publicKey
+      )
+    ).toEqual(null);
   });
 
   it('allows setting/getting of meta', (): void => {

--- a/packages/keyring/src/pair/index.spec.ts
+++ b/packages/keyring/src/pair/index.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { hexToU8a, u8aToHex } from '@polkadot/util';
-import { cryptoWaitReady, encodeAddress as toSS58, setSS58Format} from '@polkadot/util-crypto';
+import { cryptoWaitReady, encodeAddress as toSS58, setSS58Format } from '@polkadot/util-crypto';
 
 import { PAIRSSR25519 } from '../testing';
 import { createTestPairs } from '../testingPairs';
@@ -19,7 +19,7 @@ describe('pair', (): void => {
 
   const SIGNATURE = new Uint8Array([80, 191, 198, 147, 225, 207, 75, 88, 126, 39, 129, 109, 191, 38, 72, 181, 75, 254, 81, 143, 244, 79, 237, 38, 236, 141, 28, 252, 134, 26, 169, 234, 79, 33, 153, 158, 151, 34, 175, 188, 235, 20, 35, 135, 83, 120, 139, 211, 233, 130, 1, 208, 201, 215, 73, 80, 56, 98, 185, 196, 11, 8, 193, 14]);
   const ENCRYPTED = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 132, 59, 53, 85, 227, 40, 107, 48, 234, 198, 238, 157, 238, 224, 235, 179, 75, 153, 241, 142, 254]);
-  
+
   // the last byte is changed from 254 -> 253
   const ENCRYPTED_CHANGED = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 132, 59, 53, 85, 227, 40, 107, 48, 234, 198, 238, 157, 238, 224, 235, 179, 75, 153, 241, 142, 253]);
 
@@ -100,13 +100,14 @@ describe('pair', (): void => {
 
   it('allows encrypting', (): void => {
     const message = new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65]);
+
     expect(
       keyring.alice.encryptMessage(
         message,
         keyring.bob.publicKey,
         new Uint8Array(24)
       )
-    ).toEqual(ENCRYPTED)
+    ).toEqual(ENCRYPTED);
   });
 
   it('validates a correctly encrypted message', (): void => {

--- a/packages/keyring/src/pair/index.spec.ts
+++ b/packages/keyring/src/pair/index.spec.ts
@@ -161,13 +161,13 @@ describe('pair', (): void => {
     const message = new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65]);
 
     // alice-sr25519 -> bob-ed25519
-    const encrypted1 = pairA.encryptMessage(message, keyring.bob.publicKey)
+    const encrypted1 = pairA.encryptMessage(message, keyring.bob.publicKey);
 
     // alice-sr25519 -> bob-sr25519
-    const encrypted2 = pairA.encryptMessage(message, pairB.publicKey)
+    const encrypted2 = pairA.encryptMessage(message, pairB.publicKey);
 
     // alice-ed25519 -> bob-sr25519
-    const encrypted3 = keyring.alice.encryptMessage(message, pairB.publicKey)
+    const encrypted3 = keyring.alice.encryptMessage(message, pairB.publicKey);
 
     // decrypt: Bob-ed25519 - use alice-ed25519 pubkey
     expect(
@@ -273,6 +273,23 @@ describe('pair', (): void => {
         version: '3'
       });
       expect(json.address).toEqual(u8aToHex(PUBLICDERIVED));
+    });
+
+    it('denies access to encryptMessage/decryptMessage API', (): void => {
+      const PASS = 'testing';
+      const encoded = keyring.alice.encodePkcs8(PASS);
+
+      const pair = createPair({ toSS58, type: 'ethereum' }, { publicKey: keyring.alice.publicKey });
+
+      pair.decodePkcs8(PASS, encoded);
+
+      expect(
+        () => pair.encryptMessage(
+          new Uint8Array(4), // null message
+          keyring.bob.publicKey,
+          new Uint8Array(24)
+        )
+      ).toThrow('Secp256k1 not supported yet');
     });
   });
 });

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -147,6 +147,8 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     decodePkcs8,
     decryptMessage: (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
+      assert(type !== 'ecdsa', 'Secp256k1 not supported yet');
+      assert(type !== 'ethereum', 'Secp256k1 not supported yet');
 
       return naclOpen(
         u8aToU8a(encryptedMessageWithNonce.slice(24, encryptedMessageWithNonce.length)),
@@ -169,6 +171,9 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     },
     encryptMessage: (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
+
+      assert(type !== 'ecdsa', 'Secp256k1 not supported yet');
+      assert(type !== 'ethereum', 'Secp256k1 not supported yet');
 
       const { nonce, sealed } = naclSeal(u8aToU8a(message), convertSecretKeyToCurve25519(secretKey), convertPublicKeyToCurve25519(u8aToU8a(recipientPublicKey)), _nonce);
 

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -171,9 +171,7 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     },
     encryptMessage: (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
-
-      assert(type !== 'ecdsa', 'Secp256k1 not supported yet');
-      assert(type !== 'ethereum', 'Secp256k1 not supported yet');
+      assert(!['ecdsa', 'ethereum'].includes(type), 'Secp256k1 not supported yet');
 
       const { nonce, sealed } = naclSeal(u8aToU8a(message), convertSecretKeyToCurve25519(secretKey), convertPublicKeyToCurve25519(u8aToU8a(recipientPublicKey)), _nonce);
 

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -147,8 +147,7 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     decodePkcs8,
     decryptMessage: (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
-      assert(type !== 'ecdsa', 'Secp256k1 not supported yet');
-      assert(type !== 'ethereum', 'Secp256k1 not supported yet');
+      assert(!['ecdsa', 'ethereum'].includes(type), 'Secp256k1 not supported yet');
 
       return naclOpen(
         u8aToU8a(encryptedMessageWithNonce.slice(24, encryptedMessageWithNonce.length)),

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -7,7 +7,7 @@ import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta, SignOptions } fro
 import type { PairInfo } from './types';
 
 import { assert, u8aConcat, u8aEq, u8aToHex, u8aToU8a } from '@polkadot/util';
-import { blake2AsU8a, ethereumEncode, keccakAsU8a, keyExtractPath, keyFromPath, naclKeypairFromSeed as naclFromSeed, naclSign, naclSeal, naclOpen, convertPublicKeyToCurve25519, convertSecretKeyToCurve25519, schnorrkelKeypairFromSeed as schnorrkelFromSeed, schnorrkelSign, schnorrkelVrfSign, schnorrkelVrfVerify, secp256k1Compress, secp256k1Expand, secp256k1KeypairFromSeed as secp256k1FromSeed, secp256k1Sign, signatureVerify } from '@polkadot/util-crypto';
+import { blake2AsU8a, convertPublicKeyToCurve25519, convertSecretKeyToCurve25519, ethereumEncode, keccakAsU8a, keyExtractPath, keyFromPath, naclKeypairFromSeed as naclFromSeed, naclOpen, naclSeal, naclSign, schnorrkelKeypairFromSeed as schnorrkelFromSeed, schnorrkelSign, schnorrkelVrfSign, schnorrkelVrfVerify, secp256k1Compress, secp256k1Expand, secp256k1KeypairFromSeed as secp256k1FromSeed, secp256k1Sign, signatureVerify } from '@polkadot/util-crypto';
 
 import { decodePair } from './decode';
 import { encodePair } from './encode';
@@ -145,6 +145,21 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     },
     // eslint-disable-next-line sort-keys
     decodePkcs8,
+    decryptMessage: (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null => {
+      assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
+
+      const _secretKey = convertSecretKeyToCurve25519(secretKey);
+      const _senderPublicKey = convertPublicKeyToCurve25519(u8aToU8a(senderPublicKey));
+
+      const message = naclOpen(
+        u8aToU8a(encryptedMessageWithNonce.slice(24, encryptedMessageWithNonce.length)),
+        u8aToU8a(encryptedMessageWithNonce.slice(0, 24)),
+        _senderPublicKey,
+        _secretKey
+      );
+
+      return message;
+    },
     derive: (suri: string, meta?: KeyringPair$Meta): KeyringPair => {
       assert(type !== 'ethereum', 'Unable to derive on this keypair');
       assert(!isLocked(secretKey), 'Cannot derive on a locked keypair');
@@ -156,6 +171,16 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     },
     encodePkcs8: (passphrase?: string): Uint8Array => {
       return recode(passphrase);
+    },
+    encryptMessage: (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array => {
+      assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
+
+      const _secretKey = convertSecretKeyToCurve25519(secretKey);
+      const _recipientPublicKey = convertPublicKeyToCurve25519(u8aToU8a(recipientPublicKey));
+
+      const { nonce, sealed } = naclSeal(u8aToU8a(message), _secretKey, _recipientPublicKey, _nonce);
+
+      return u8aConcat(nonce, sealed);
     },
     lock: (): void => {
       secretKey = new Uint8Array();
@@ -190,31 +215,6 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     },
     verify: (message: string | Uint8Array, signature: Uint8Array, _signerPublic: string | Uint8Array): boolean => {
       return signatureVerify(message, signature, TYPE_ADDRESS[type](u8aToU8a(_signerPublic))).isValid;
-    },
-    encryptMessage: (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array => {
-      assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
-
-      const _secretKey = convertSecretKeyToCurve25519(secretKey);
-      const _recipientPublicKey = convertPublicKeyToCurve25519(u8aToU8a(recipientPublicKey));
-
-      const { nonce, sealed } = naclSeal(u8aToU8a(message), _secretKey, _recipientPublicKey, _nonce);
-
-      return u8aConcat(nonce, sealed);
-    },
-    decryptMessage: (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null=> {
-      assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
-
-      const _secretKey = convertSecretKeyToCurve25519(secretKey);
-      const _senderPublicKey = convertPublicKeyToCurve25519(u8aToU8a(senderPublicKey));
-
-      const message = naclOpen(
-        u8aToU8a(encryptedMessageWithNonce.slice(24, encryptedMessageWithNonce.length)),
-        u8aToU8a(encryptedMessageWithNonce.slice(0, 24)),
-        _senderPublicKey,
-        _secretKey
-      );
-
-      return message;
     },
     vrfSign: (message: string | Uint8Array, context?: string | Uint8Array, extra?: string | Uint8Array): Uint8Array => {
       assert(!isLocked(secretKey), 'Cannot sign with a locked key pair');

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -148,17 +148,12 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     decryptMessage: (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
 
-      const _secretKey = convertSecretKeyToCurve25519(secretKey);
-      const _senderPublicKey = convertPublicKeyToCurve25519(u8aToU8a(senderPublicKey));
-
-      const message = naclOpen(
+      return naclOpen(
         u8aToU8a(encryptedMessageWithNonce.slice(24, encryptedMessageWithNonce.length)),
         u8aToU8a(encryptedMessageWithNonce.slice(0, 24)),
-        _senderPublicKey,
-        _secretKey
+        convertPublicKeyToCurve25519(u8aToU8a(senderPublicKey)),
+        convertSecretKeyToCurve25519(secretKey)
       );
-
-      return message;
     },
     derive: (suri: string, meta?: KeyringPair$Meta): KeyringPair => {
       assert(type !== 'ethereum', 'Unable to derive on this keypair');
@@ -175,10 +170,7 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     encryptMessage: (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
 
-      const _secretKey = convertSecretKeyToCurve25519(secretKey);
-      const _recipientPublicKey = convertPublicKeyToCurve25519(u8aToU8a(recipientPublicKey));
-
-      const { nonce, sealed } = naclSeal(u8aToU8a(message), _secretKey, _recipientPublicKey, _nonce);
+      const { nonce, sealed } = naclSeal(u8aToU8a(message), convertSecretKeyToCurve25519(secretKey), convertPublicKeyToCurve25519(u8aToU8a(recipientPublicKey)), _nonce);
 
       return u8aConcat(nonce, sealed);
     },

--- a/packages/keyring/src/pair/nobody.ts
+++ b/packages/keyring/src/pair/nobody.ts
@@ -30,11 +30,17 @@ export function nobody (): KeyringPair {
     decodePkcs8: (passphrase?: string, encoded?: Uint8Array): void =>
       undefined,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    decryptMessage: (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null =>
+      null,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     derive: (suri: string, meta?: KeyringPair$Meta): KeyringPair =>
       pair,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     encodePkcs8: (passphrase?: string): Uint8Array =>
       new Uint8Array(0),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    encryptMessage: (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array =>
+      new Uint8Array(),
     isLocked: true,
     lock: (): void => {
       // no locking, it is always locked

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -37,6 +37,8 @@ export interface KeyringPair {
   sign (message: string | Uint8Array, options?: SignOptions): Uint8Array;
   toJson (passphrase?: string): KeyringPair$Json;
   unlock (passphrase?: string): void;
+  encryptMessage (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, nonce?: Uint8Array): Uint8Array;
+  decryptMessage (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null;
   verify (message: string | Uint8Array, signature: Uint8Array, signerPublic: string | Uint8Array): boolean;
   vrfSign (message: string | Uint8Array, context?: string | Uint8Array, extra?: string | Uint8Array): Uint8Array;
   vrfVerify (message: string | Uint8Array, vrfResult: Uint8Array, signerPublic: Uint8Array | string, context?: string | Uint8Array, extra?: string | Uint8Array): boolean;

--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -31,6 +31,7 @@
     "blakejs": "^1.1.1",
     "bn.js": "^4.11.9",
     "create-hash": "^1.2.0",
+    "ed2curve": "^0.3.0",
     "elliptic": "^6.5.4",
     "hash.js": "^1.1.7",
     "js-sha3": "^0.8.0",

--- a/packages/util-crypto/src/nacl/convertKey.ts
+++ b/packages/util-crypto/src/nacl/convertKey.ts
@@ -1,0 +1,13 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// @ts-ignore
+import ed2curve from 'ed2curve'
+
+export function convertSecretKeyToCurve25519(secretKey: Uint8Array): Uint8Array {
+  return ed2curve.convertSecretKey(secretKey);
+}
+
+export function convertPublicKeyToCurve25519(publicKey: Uint8Array): Uint8Array {
+  return ed2curve.convertPublicKey(publicKey);
+}

--- a/packages/util-crypto/src/nacl/convertKey.ts
+++ b/packages/util-crypto/src/nacl/convertKey.ts
@@ -1,15 +1,12 @@
 // Copyright 2017-2021 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-/* eslint-disable */
-// @ts-ignore
 import ed2curve from 'ed2curve';
 
 export function convertSecretKeyToCurve25519 (secretKey: Uint8Array): Uint8Array {
-  return ed2curve.convertSecretKey(secretKey) as Uint8Array;
+  return ed2curve.convertSecretKey(secretKey);
 }
 
 export function convertPublicKeyToCurve25519 (publicKey: Uint8Array): Uint8Array {
   return ed2curve.convertPublicKey(publicKey) as Uint8Array;
 }
-/* eslint-enable */

--- a/packages/util-crypto/src/nacl/convertKey.ts
+++ b/packages/util-crypto/src/nacl/convertKey.ts
@@ -1,13 +1,15 @@
 // Copyright 2017-2021 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable */
 // @ts-ignore
-import ed2curve from 'ed2curve'
+import ed2curve from 'ed2curve';
 
-export function convertSecretKeyToCurve25519(secretKey: Uint8Array): Uint8Array {
-  return ed2curve.convertSecretKey(secretKey);
+export function convertSecretKeyToCurve25519 (secretKey: Uint8Array): Uint8Array {
+  return ed2curve.convertSecretKey(secretKey) as Uint8Array;
 }
 
-export function convertPublicKeyToCurve25519(publicKey: Uint8Array): Uint8Array {
-  return ed2curve.convertPublicKey(publicKey);
+export function convertPublicKeyToCurve25519 (publicKey: Uint8Array): Uint8Array {
+  return ed2curve.convertPublicKey(publicKey) as Uint8Array;
 }
+/* eslint-enable */

--- a/packages/util-crypto/src/nacl/index.ts
+++ b/packages/util-crypto/src/nacl/index.ts
@@ -15,7 +15,7 @@ export { naclVerify } from './verify';
 export { naclBoxKeypairFromSecret } from './box/fromSecret';
 export { naclOpen } from './open';
 export { naclSeal } from './seal';
-export { 
+export {
   convertSecretKeyToCurve25519,
-  convertPublicKeyToCurve25519,
-} from './convertKey'
+  convertPublicKeyToCurve25519
+} from './convertKey';

--- a/packages/util-crypto/src/nacl/index.ts
+++ b/packages/util-crypto/src/nacl/index.ts
@@ -15,3 +15,7 @@ export { naclVerify } from './verify';
 export { naclBoxKeypairFromSecret } from './box/fromSecret';
 export { naclOpen } from './open';
 export { naclSeal } from './seal';
+export { 
+  convertSecretKeyToCurve25519,
+  convertPublicKeyToCurve25519,
+} from './convertKey'

--- a/packages/util-crypto/src/nacl/index.ts
+++ b/packages/util-crypto/src/nacl/index.ts
@@ -15,7 +15,4 @@ export { naclVerify } from './verify';
 export { naclBoxKeypairFromSecret } from './box/fromSecret';
 export { naclOpen } from './open';
 export { naclSeal } from './seal';
-export {
-  convertSecretKeyToCurve25519,
-  convertPublicKeyToCurve25519
-} from './convertKey';
+export { convertSecretKeyToCurve25519, convertPublicKeyToCurve25519 } from './convertKey';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,6 +2122,7 @@ __metadata:
     blakejs: ^1.1.1
     bn.js: ^4.11.9
     create-hash: ^1.2.0
+    ed2curve: ^0.3.0
     elliptic: ^6.5.4
     hash.js: ^1.1.7
     js-sha3: ^0.8.0
@@ -4732,6 +4733,15 @@ __metadata:
     jsbn: ~0.1.0
     safer-buffer: ^2.1.0
   checksum: 22fef4b6203e5f31d425f5b711eb389e4c6c2723402e389af394f8411b76a488fa414d309d866e2b577ce3e8462d344205545c88a8143cc21752a5172818888a
+  languageName: node
+  linkType: hard
+
+"ed2curve@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "ed2curve@npm:0.3.0"
+  dependencies:
+    tweetnacl: 1.x.x
+  checksum: 6dfbe2310aa5a47372c9dd2fd920be140c8d52aea5793d716a3e3865d2ceaeaf639a7653e5492dfe3b4910eaf65c09a1d5132580afe2fdca18a75ebb428a52f2
   languageName: node
   linkType: hard
 
@@ -10904,17 +10914,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"tweetnacl@npm:1.x.x, tweetnacl@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "tweetnacl@npm:1.0.3"
+  checksum: e4a57cac188f0c53f24c7a33279e223618a2bfb5fea426231991652a13247bea06b081fd745d71291fcae0f4428d29beba1b984b1f1ce6f66b06a6d1ab90645c
+  languageName: node
+  linkType: hard
+
 "tweetnacl@npm:^0.14.3, tweetnacl@npm:~0.14.0":
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
   checksum: 6061daba1724f59473d99a7bb82e13f211cdf6e31315510ae9656fefd4779851cb927adad90f3b488c8ed77c106adc0421ea8055f6f976ff21b27c5c4e918487
-  languageName: node
-  linkType: hard
-
-"tweetnacl@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "tweetnacl@npm:1.0.3"
-  checksum: e4a57cac188f0c53f24c7a33279e223618a2bfb5fea426231991652a13247bea06b081fd745d71291fcae0f4428d29beba1b984b1f1ce6f66b06a6d1ab90645c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,6 +2446,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ed2curve@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@types/ed2curve@npm:0.2.2"
+  dependencies:
+    tweetnacl: ^1.0.0
+  checksum: f1ab16d46c5eed50d51539effef76c87806bb53ab45ecff78c19a632e63825fd08d604984b08778f8201c79be0bd43120565dad38cc5d45ba65a6c7de5bf4ace
+  languageName: node
+  linkType: hard
+
 "@types/elliptic@npm:^6.4.13":
   version: 6.4.13
   resolution: "@types/elliptic@npm:6.4.13"
@@ -9877,6 +9886,7 @@ resolve@^2.0.0-next.3:
     "@babel/core": ^7.14.8
     "@polkadot/dev": ^0.62.57
     "@polkadot/ts": ^0.4.4
+    "@types/ed2curve": ^0.2.2
     "@types/jest": ^26.0.24
   languageName: unknown
   linkType: soft
@@ -10914,7 +10924,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tweetnacl@npm:1.x.x, tweetnacl@npm:^1.0.3":
+"tweetnacl@npm:1.x.x, tweetnacl@npm:^1.0.0, tweetnacl@npm:^1.0.3":
   version: 1.0.3
   resolution: "tweetnacl@npm:1.0.3"
   checksum: e4a57cac188f0c53f24c7a33279e223618a2bfb5fea426231991652a13247bea06b081fd745d71291fcae0f4428d29beba1b984b1f1ce6f66b06a6d1ab90645c


### PR DESCRIPTION
Ref: https://github.com/polkadot-js/common/issues/1068

- 1 dependency added to 'util-crypto' - `ed2curve` by the author of tweetnacl.js 
- tests included
- covers sr25519 & ed25519, secp256k1 to be added. 