### PR TITLE
Update dock networks to latest specs

### DIFF
--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -10,7 +10,7 @@ import { newBifrostApp, newCentrifugeApp, newDockApp, newEdgewareApp, newEquilib
 export const ledgerApps: Record<string, (transport: Transport) => SubstrateApp> = {
   bifrost: newBifrostApp,
   centrifuge: newCentrifugeApp,
-  'dock-mainnet': newDockApp,
+  'dock-pos-mainnet': newDockApp,
   edgeware: newEdgewareApp,
   equilibrium: newEquilibriumApp,
   genshiro: newGenshiroApp,

--- a/packages/networks/src/defaults.ts
+++ b/packages/networks/src/defaults.ts
@@ -24,7 +24,7 @@ export const knownIcon: KnownIcon = {
 export const knownLedger: KnownLedger = {
   bifrost: 0x00000314,
   centrifuge: 0x000002eb,
-  'dock-mainnet': 0x00000252,
+  'dock-pos-mainnet': 0x00000252,
   edgeware: 0x0000020b,
   equilibrium: 0x05f5e0fd,
   genshiro: 0x05f5e0fc,
@@ -40,7 +40,7 @@ export const knownLedger: KnownLedger = {
 export const knownTestnet: KnownTestnet = {
   '': true, // this is the default non-network entry
   'cess-testnet': true,
-  'dock-testnet': true,
+  'dock-pos-testnet': true,
   jupiter: true,
   'mathchain-testnet': true,
   subspace_testnet: true,

--- a/packages/networks/src/genesis.ts
+++ b/packages/networks/src/genesis.ts
@@ -23,8 +23,8 @@ export const knownGenesis: KnownGenesis = {
   centrifuge: [
     '0x67dddf2673b69e5f875f6f25277495834398eafd67f492e09f3f3345e003d1b5'
   ],
-  'dock-mainnet': [
-    '0xf73467c6544aa68df2ee546b135f955c46b90fa627e9b5d7935f41061bb8a5a9'
+  'dock-pos-mainnet': [
+    '0x6bfe24dca2a3be10f22212678ac13a6446ec764103c0f3471c71609eac384aae'
   ],
   edgeware: [
     '0x742a2ca70c2fda6cee4f8df98d64c4c670a052d9568058982dad9d5a7a135c5b'

--- a/packages/networks/src/test/ss58registry.test.json
+++ b/packages/networks/src/test/ss58registry.test.json
@@ -260,7 +260,7 @@
   },
   {
     "prefix": 21,
-    "network": "dock-testnet",
+    "network": "dock-pos-testnet",
     "displayName": "Dock Testnet",
     "symbols": [
       "DCK"
@@ -273,7 +273,7 @@
   },
   {
     "prefix": 22,
-    "network": "dock-mainnet",
+    "network": "dock-pos-mainnet",
     "displayName": "Dock Mainnet",
     "symbols": [
       "DCK"


### PR DESCRIPTION
Dock had a change from a PoA network to PoS not too long ago, the PoA network is no longer online. Latest spec names and genesis hashes are provided in this PR