### PR TITLE
Use `Buffer` for hex encoding/decoding and concatenation on Node.js

### DIFF
--- a/packages/util/src/hex/toU8a.ts
+++ b/packages/util/src/hex/toU8a.ts
@@ -30,6 +30,11 @@ export function hexToU8a (_value?: HexString | string | null, bitLength = -1): U
   assert(isHex(_value), () => `Expected hex value to convert, found '${_value}'`);
 
   const value = hexStripPrefix(_value);
+
+  if (bitLength === -1 && typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(value, 'hex'));
+  }
+
   const valLength = value.length / 2;
   const bufLength = Math.ceil(
     bitLength === -1

--- a/packages/util/src/u8a/concat.ts
+++ b/packages/util/src/u8a/concat.ts
@@ -32,6 +32,10 @@ export function u8aConcat (...list: U8aLike[]): Uint8Array {
     length += u8as[i].length;
   }
 
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.concat(u8as));
+  }
+
   const result = new Uint8Array(length);
 
   for (let i = 0; i < u8as.length; i++) {

--- a/packages/util/src/u8a/toHex.ts
+++ b/packages/util/src/u8a/toHex.ts
@@ -52,6 +52,10 @@ export function u8aToHex (value?: Uint8Array | null, bitLength = -1, isPrefixed 
   return `${isPrefixed ? '0x' : ''}${
     !value || !value.length
       ? ''
-      : unprefixed(value, bitLength)
+      : (
+        bitLength === -1 && typeof Buffer !== 'undefined'
+          ? Buffer.from(value).toString('hex')
+          : unprefixed(value, bitLength)
+      )
   }` as HexString;
 }


### PR DESCRIPTION
Turns out iterating byte after byte in Node.js is not the fastest thing in the world, why not using `Buffer` that can offload this to native code (potentially with SIMD, etc.).