### PR TITLE
Internal base58 decode/encode

### DIFF
--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -30,7 +30,6 @@
     "@polkadot/util": "7.8.3-27",
     "@polkadot/wasm-crypto": "^4.2.1",
     "@polkadot/x-randomvalues": "7.8.3-27",
-    "base-x": "^3.0.9",
     "base64-js": "^1.5.1",
     "blakejs": "^1.1.1",
     "bn.js": "^4.12.0",

--- a/packages/util-crypto/src/base58/base-x.ts
+++ b/packages/util-crypto/src/base58/base-x.ts
@@ -1,0 +1,170 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Original: https://github.com/cryptocoinjs/base-x/blob/d37ae5deee181018cf6f25833fc26b3551ea9fe6/ts_src/index.ts
+//
+// base-x encoding / decoding
+// Copyright (c) 2018 base-x contributors
+// Copyright (c) 2014-2018 The Bitcoin Core developers (base58.cpp)
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+// Notes on changes:
+//   - converted to only operate on Uint8Array in/out (as per the PR it is from)
+//   - use @polkadot/util as applicable
+//   - convery decodeU/nsafe to decode (only point used)
+//   - skip unneeded checks (conversion on layer above)
+//   - it should just take care of bs58, however keeping it generic for now
+
+import type { BaseConverter } from './types';
+
+import { assert } from '@polkadot/util';
+
+export default function baseX (type: 'base58', ALPHABET: string): BaseConverter {
+  assert(ALPHABET.length < 255, 'Alphabet too long');
+
+  const BASE_MAP = new Uint8Array(256);
+
+  BASE_MAP.fill(255);
+
+  for (let i = 0; i < ALPHABET.length; i++) {
+    const x = ALPHABET.charAt(i);
+    const xc = x.charCodeAt(0);
+
+    assert(BASE_MAP[xc] === 255, `${x} is ambiguous`);
+
+    BASE_MAP[xc] = i;
+  }
+
+  const BASE = ALPHABET.length;
+  const BASE_ERROR = `Non-base ${type} character`;
+  const LEADER = ALPHABET.charAt(0);
+  const FACTOR = Math.log(BASE) / Math.log(256); // log(BASE) / log(256), rounded up
+  const iFACTOR = Math.log(256) / Math.log(BASE); // log(256) / log(BASE), rounded up
+
+  function encode (source: Uint8Array): string {
+    if (source.length === 0) {
+      return '';
+    }
+
+    // Skip & count leading zeroes.
+    let zeroes = 0;
+    let length = 0;
+    let pbegin = 0;
+    const pend = source.length;
+
+    while (pbegin !== pend && source[pbegin] === 0) {
+      pbegin++;
+      zeroes++;
+    }
+
+    // Allocate enough space in big-endian base58 representation.
+    const size = ((pend - pbegin) * iFACTOR + 1) >>> 0;
+    const b58 = new Uint8Array(size);
+
+    // Process the bytes.
+    while (pbegin !== pend) {
+      let carry = source[pbegin];
+
+      // Apply "b58 = b58 * 256 + ch".
+      let i = 0;
+
+      for (let it1 = size - 1; (carry !== 0 || i < length) && (it1 !== -1); it1--, i++) {
+        carry += (256 * b58[it1]) >>> 0;
+        b58[it1] = (carry % BASE) >>> 0;
+        carry = (carry / BASE) >>> 0;
+      }
+
+      assert(carry === 0, 'Non-zero carry');
+
+      length = i;
+      pbegin++;
+    }
+
+    // Skip leading zeroes in base58 result.
+    let it2 = size - length;
+
+    while (it2 !== size && b58[it2] === 0) {
+      it2++;
+    }
+
+    // Translate the result into a string.
+    let str = LEADER.repeat(zeroes);
+
+    for (; it2 < size; ++it2) {
+      str += ALPHABET.charAt(b58[it2]);
+    }
+
+    return str;
+  }
+
+  function decode (source: string): Uint8Array {
+    if (source.length === 0) {
+      return new Uint8Array();
+    }
+
+    let psz = 0;
+
+    // Skip leading spaces.
+    assert(source[psz] !== ' ', BASE_ERROR);
+
+    // Skip and count leading '1's.
+    let zeroes = 0;
+    let length = 0;
+
+    while (source[psz] === LEADER) {
+      zeroes++;
+      psz++;
+    }
+
+    // Allocate enough space in big-endian base256 representation.
+    const size = (((source.length - psz) * FACTOR) + 1) >>> 0; // log(58) / log(256), rounded up.
+    const b256 = new Uint8Array(size);
+
+    // Process the characters.
+    while (source[psz]) {
+      // Decode character
+      let carry = BASE_MAP[source.charCodeAt(psz)];
+
+      // Invalid character
+      assert(carry !== 255, BASE_ERROR);
+
+      let i = 0;
+
+      for (let it3 = size - 1; (carry !== 0 || i < length) && (it3 !== -1); it3--, i++) {
+        carry += (BASE * b256[it3]) >>> 0;
+        b256[it3] = (carry % 256) >>> 0;
+        carry = (carry / 256) >>> 0;
+      }
+
+      assert(carry === 0, 'Non-zero carry');
+
+      length = i;
+      psz++;
+    }
+
+    // Skip trailing spaces.
+    assert(source[psz] !== ' ', BASE_ERROR);
+
+    // Skip leading zeroes in b256.
+    let it4 = size - length;
+
+    while (it4 !== size && b256[it4] === 0) {
+      it4++;
+    }
+
+    const result = new Uint8Array(zeroes + (size - it4));
+    let j = zeroes;
+
+    while (it4 !== size) {
+      result[j++] = b256[it4++];
+    }
+
+    return result;
+  }
+
+  return {
+    decode,
+    encode
+  };
+}

--- a/packages/util-crypto/src/base58/bs58.ts
+++ b/packages/util-crypto/src/base58/bs58.ts
@@ -1,9 +1,9 @@
 // Copyright 2017-2021 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import baseX from 'base-x';
+import baseX from './base-x';
 
 // https://github.com/cryptocoinjs/base-x#alphabets
 export const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
-export const bs58 = baseX(BASE58_ALPHABET);
+export const bs58 = baseX('base58', BASE58_ALPHABET);

--- a/packages/util-crypto/src/base58/encode.spec.ts
+++ b/packages/util-crypto/src/base58/encode.spec.ts
@@ -4,13 +4,18 @@
 import { base32Decode } from '../base32';
 import { base58Encode } from './';
 
+const test = base32Decode('bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', true);
+
 describe('base58Encode', (): void => {
-  it('encodes a base32 to a base38', (): void => {
+  it('encodes a base58', (): void => {
     expect(
-      base58Encode(
-        base32Decode('bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', true),
-        true
-      )
+      base58Encode(test)
+    ).toEqual('b2rhk6GMPQF3hfzwXTaNYFLKomMeC6UXdUt6jZKPpeVirLtV');
+  });
+
+  it('encodes a base58 (ipfs format)', (): void => {
+    expect(
+      base58Encode(test, true)
     ).toEqual('zb2rhk6GMPQF3hfzwXTaNYFLKomMeC6UXdUt6jZKPpeVirLtV');
   });
 });

--- a/packages/util-crypto/src/base58/types.ts
+++ b/packages/util-crypto/src/base58/types.ts
@@ -1,0 +1,7 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export interface BaseConverter {
+  encode (buffer: Uint8Array): string;
+  decode (string: string): Uint8Array;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,7 +2093,6 @@ __metadata:
     "@types/elliptic": ^6.4.14
     "@types/scryptsy": ^2.0.0
     "@types/xxhashjs": ^0.2.2
-    base-x: ^3.0.9
     base64-js: ^1.5.1
     blakejs: ^1.1.1
     bn.js: ^4.12.0
@@ -3367,7 +3366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.2, base-x@npm:^3.0.9":
+"base-x@npm:^3.0.2":
   version: 3.0.9
   resolution: "base-x@npm:3.0.9"
   dependencies:


### PR DESCRIPTION
Follows on the `@noble/*` changes, e.g. the underlying libs needing the same base-x have been culled, and this has deep Buffer dependencies.