### PR TITLE
Preserve all-caps word splits in `stringCamelCase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 
 - Swap to upstream `@noble/hashes`
+- Preserve all-caps word splits in `stringCamelCase`
 
 
 ## 8.1.2 Dec 5, 2021

--- a/packages/util/src/string/camelCase.spec.ts
+++ b/packages/util/src/string/camelCase.spec.ts
@@ -68,6 +68,9 @@ describe('stringCamelCase', (): void => {
     expect(
       stringCamelCase('BLAKE2B')
     ).toEqual('blake2b');
+    expect(
+      stringCamelCase('NFTOrder')
+    ).toEqual('nftOrder');
   });
 
   it('adjusts with leading _', (): void => {

--- a/packages/util/src/string/camelCase.spec.ts
+++ b/packages/util/src/string/camelCase.spec.ts
@@ -83,6 +83,9 @@ describe('stringCamelCase', (): void => {
     expect(
       stringCamelCase('A1B')
     ).toEqual('a1b');
+    expect(
+      stringCamelCase('RawVRFOutput')
+    ).toEqual('rawVRFOutput');
   });
 
   it('adjusts with leading _', (): void => {

--- a/packages/util/src/string/camelCase.spec.ts
+++ b/packages/util/src/string/camelCase.spec.ts
@@ -72,6 +72,9 @@ describe('stringCamelCase', (): void => {
       stringCamelCase('NFTOrder')
     ).toEqual('nftOrder');
     expect(
+      stringCamelCase('EVM')
+    ).toEqual('evm');
+    expect(
       stringCamelCase('A')
     ).toEqual('a');
     expect(

--- a/packages/util/src/string/camelCase.spec.ts
+++ b/packages/util/src/string/camelCase.spec.ts
@@ -71,6 +71,18 @@ describe('stringCamelCase', (): void => {
     expect(
       stringCamelCase('NFTOrder')
     ).toEqual('nftOrder');
+    expect(
+      stringCamelCase('A')
+    ).toEqual('a');
+    expect(
+      stringCamelCase('A1')
+    ).toEqual('a1');
+    expect(
+      stringCamelCase('A1b')
+    ).toEqual('a1b');
+    expect(
+      stringCamelCase('A1B')
+    ).toEqual('a1b');
   });
 
   it('adjusts with leading _', (): void => {

--- a/packages/util/src/string/camelCase.ts
+++ b/packages/util/src/string/camelCase.ts
@@ -10,7 +10,7 @@ import type { AnyString } from '../types';
 // a 10+x improvement over the original camelcase npm package (at running)
 //
 // original: 20.88 μs/op
-//     this:  3.05 μs/op
+//     this:  2.86 μs/op
 //
 // Caveat of this: only Ascii, but acceptable for the intended usecase
 function converter (fn: (w: string, i: number) => string): (value: AnyString) => string {
@@ -33,7 +33,7 @@ function converter (fn: (w: string, i: number) => string): (value: AnyString) =>
             ? w.toLowerCase()
             // all consecutive capitals + letters are changed to lowercase
             // e.g. UUID64 -> uuid64, while preserving splits, eg. NFTOrder -> nftOrder
-            : w.replace(/^[A-Z0-9]{1,}[^a-z]/, (w) =>
+            : w.replace(/^[A-Z0-9]{2,}[^a-z]/, (w) =>
               w.slice(0, w.length - 1).toLowerCase() + w.slice(-1).toUpperCase()
             ),
           i

--- a/packages/util/src/string/camelCase.ts
+++ b/packages/util/src/string/camelCase.ts
@@ -10,7 +10,7 @@ import type { AnyString } from '../types';
 // a 10+x improvement over the original camelcase npm package (at running)
 //
 // original: 20.88 μs/op
-//     this:  2.97 μs/op
+//     this:  3.05 μs/op
 //
 // Caveat of this: only Ascii, but acceptable for the intended usecase
 function converter (fn: (w: string, i: number) => string): (value: AnyString) => string {
@@ -32,7 +32,10 @@ function converter (fn: (w: string, i: number) => string): (value: AnyString) =>
             // all full uppercase + letters are changed to lowercase
             ? w.toLowerCase()
             // all consecutive capitals + letters are changed to lowercase
-            : w.replace(/[A-Z]{2,}[0-9]{2,}/g, (w) => w.toLowerCase()),
+            // e.g. UUID64 -> uuid64, while preserving splits, eg. NFTOrder -> nftOrder
+            : w.replace(/^[A-Z0-9]{1,}[^a-z]/, (w) =>
+              w.slice(0, w.length - 1).toLowerCase() + w.slice(-1).toUpperCase()
+            ),
           i
         )
       )


### PR DESCRIPTION
Re-introduce old-style word splits based on TLA ordering.

Closes https://github.com/polkadot-js/common/issues/1286