### PR TITLE
Include sender's public key in the encrypted message 

### DIFF
--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -7,7 +7,7 @@ import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta, SignOptions } fro
 import type { PairInfo } from './types';
 
 import { assert, objectSpread, u8aConcat, u8aEmpty, u8aEq, u8aToHex, u8aToU8a } from '@polkadot/util';
-import { blake2AsU8a, convertPublicKeyToCurve25519, convertSecretKeyToCurve25519, ed25519PairFromSeed as ed25519FromSeed, ed25519Sign, ethereumEncode, keccakAsU8a, keyExtractPath, keyFromPath, naclOpen, naclSeal, secp256k1Compress, secp256k1Expand, secp256k1PairFromSeed as secp256k1FromSeed, secp256k1Sign, signatureVerify, sr25519PairFromSeed as sr25519FromSeed, sr25519Sign, sr25519VrfSign, sr25519VrfVerify } from '@polkadot/util-crypto';
+import { blake2AsU8a, convertPublicKeyToCurve25519, convertSecretKeyToCurve25519, ed25519PairFromSeed as ed25519FromSeed, ed25519Sign, ethereumEncode, keccakAsU8a, keyExtractPath, keyFromPath, naclBoxPairFromSecret, naclOpen, naclSeal, secp256k1Compress, secp256k1Expand, secp256k1PairFromSeed as secp256k1FromSeed, secp256k1Sign, signatureVerify, sr25519PairFromSeed as sr25519FromSeed, sr25519Sign, sr25519VrfSign, sr25519VrfVerify } from '@polkadot/util-crypto';
 
 import { decodePair } from './decode';
 import { encodePair } from './encode';
@@ -144,16 +144,16 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     },
     // eslint-disable-next-line sort-keys
     decodePkcs8,
-    decryptMessage: (encryptedMessageWithNonce: HexString | string | Uint8Array, senderPublicKey: HexString | string | Uint8Array): Uint8Array | null => {
+    decryptMessage: (encryptedMessageWithNonce: HexString | string | Uint8Array): Uint8Array | null => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
       assert(!['ecdsa', 'ethereum'].includes(type), 'Secp256k1 not supported yet');
 
       const messageU8a = u8aToU8a(encryptedMessageWithNonce);
 
       return naclOpen(
-        messageU8a.slice(24, messageU8a.length),
-        messageU8a.slice(0, 24),
-        convertPublicKeyToCurve25519(u8aToU8a(senderPublicKey)),
+        messageU8a.slice(56, messageU8a.length),
+        messageU8a.slice(32, 56),
+        messageU8a.slice(0, 32),
         convertSecretKeyToCurve25519(secretKey)
       );
     },
@@ -175,7 +175,7 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
 
       const { nonce, sealed } = naclSeal(u8aToU8a(message), convertSecretKeyToCurve25519(secretKey), convertPublicKeyToCurve25519(u8aToU8a(recipientPublicKey)), nonceIn);
 
-      return u8aConcat(nonce, sealed);
+      return u8aConcat(naclBoxPairFromSecret(convertSecretKeyToCurve25519(secretKey)).publicKey, nonce, sealed);
     },
     lock: (): void => {
       secretKey = new Uint8Array();

--- a/packages/keyring/src/pair/nobody.ts
+++ b/packages/keyring/src/pair/nobody.ts
@@ -31,7 +31,7 @@ const pair: KeyringPair = {
   decodePkcs8: (passphrase?: string, encoded?: Uint8Array): void =>
     undefined,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  decryptMessage: (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null =>
+  decryptMessage: (encryptedMessageWithNonce: string | Uint8Array): Uint8Array | null =>
     null,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   derive: (suri: string, meta?: KeyringPair$Meta): KeyringPair =>

--- a/packages/keyring/src/pair/nobody.ts
+++ b/packages/keyring/src/pair/nobody.ts
@@ -40,8 +40,9 @@ const pair: KeyringPair = {
   encodePkcs8: (passphrase?: string): Uint8Array =>
     new Uint8Array(0),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  encryptMessage: (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array =>
+  encryptMessage: (message: string | Uint8Array, recipientEncryptionPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array =>
     new Uint8Array(),
+  encryptionPublicKey: new Uint8Array(0),
   isLocked: true,
   lock: (): void => {
     // no locking, it is always locked

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -23,6 +23,7 @@ export interface SignOptions {
 export interface KeyringPair {
   readonly address: string;
   readonly addressRaw: Uint8Array;
+  readonly encryptionPublicKey: Uint8Array;
   readonly meta: KeyringPair$Meta;
   readonly isLocked: boolean;
   readonly publicKey: Uint8Array;
@@ -36,7 +37,7 @@ export interface KeyringPair {
   sign (message: HexString | string | Uint8Array, options?: SignOptions): Uint8Array;
   toJson (passphrase?: string): KeyringPair$Json;
   unlock (passphrase?: string): void;
-  encryptMessage (message: HexString | string | Uint8Array, recipientPublicKey: HexString | string | Uint8Array, nonce?: Uint8Array): Uint8Array;
+  encryptMessage(message: HexString | string | Uint8Array, recipientEncryptionPublicKey: HexString | string | Uint8Array, nonce?: Uint8Array): Uint8Array;
   decryptMessage (encryptedMessageWithNonce: HexString | string | Uint8Array): Uint8Array | null;
   verify (message: HexString | string | Uint8Array, signature: Uint8Array, signerPublic: HexString | string | Uint8Array): boolean;
   vrfSign (message: HexString | string | Uint8Array, context?: HexString | string | Uint8Array, extra?: HexString | string | Uint8Array): Uint8Array;

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -37,7 +37,7 @@ export interface KeyringPair {
   toJson (passphrase?: string): KeyringPair$Json;
   unlock (passphrase?: string): void;
   encryptMessage (message: HexString | string | Uint8Array, recipientPublicKey: HexString | string | Uint8Array, nonce?: Uint8Array): Uint8Array;
-  decryptMessage (encryptedMessageWithNonce: HexString | string | Uint8Array, senderPublicKey: HexString | string | Uint8Array): Uint8Array | null;
+  decryptMessage (encryptedMessageWithNonce: HexString | string | Uint8Array): Uint8Array | null;
   verify (message: HexString | string | Uint8Array, signature: Uint8Array, signerPublic: HexString | string | Uint8Array): boolean;
   vrfSign (message: HexString | string | Uint8Array, context?: HexString | string | Uint8Array, extra?: HexString | string | Uint8Array): Uint8Array;
   vrfVerify (message: HexString | string | Uint8Array, vrfResult: Uint8Array, signerPublic: HexString | Uint8Array | string, context?: HexString | string | Uint8Array, extra?: HexString | string | Uint8Array): boolean;


### PR DESCRIPTION
This fixes https://github.com/polkadot-js/common/issues/1314 and added the code posted by @LaurentTrk in the tests. 