### PR TITLE
Asymmetric encryption/decryption feature

### DIFF
--- a/packages/keyring/src/keyring.ts
+++ b/packages/keyring/src/keyring.ts
@@ -5,7 +5,7 @@ import type { EncryptedJsonEncoding, Keypair, KeypairType } from '@polkadot/util
 import type { KeyringInstance, KeyringOptions, KeyringPair, KeyringPair$Json, KeyringPair$Meta } from './types';
 
 import { assert, hexToU8a, isHex, isUndefined, stringToU8a } from '@polkadot/util';
-import { base64Decode, decodeAddress, ed25519PairFromSeed as ed25519FromSeed, encodeAddress, ethereumEncode, hdEthereum, keyExtractSuri, keyFromPath, mnemonicToLegacySeed, mnemonicToMiniSecret, secp256k1PairFromSeed as secp256k1FromSeed, sr25519PairFromSeed as sr25519FromSeed } from '@polkadot/util-crypto';
+import { base64Decode, decodeAddress, ed25519PairFromSeed as ed25519FromSeed, encodeAddress, encrypt as cryptoEncrypt, ethereumEncode, hdEthereum, keyExtractSuri, keyFromPath, mnemonicToLegacySeed, mnemonicToMiniSecret, secp256k1PairFromSeed as secp256k1FromSeed, sr25519PairFromSeed as sr25519FromSeed } from '@polkadot/util-crypto';
 
 import { DEV_PHRASE } from './defaults';
 import { createPair } from './pair';
@@ -295,5 +295,15 @@ export class Keyring implements KeyringInstance {
    */
   public toJson (address: string | Uint8Array, passphrase?: string): KeyringPair$Json {
     return this.#pairs.get(address).toJson(passphrase);
+  }
+
+  /**
+   * @name encrypt
+   * @summary Encrypt a message using the given publickey
+   * @description Returns the encrypted message of the given message using the public key.
+   * The encrypted message can be decrypted by the corresponding keypair using keypair.decrypt() method
+   */
+  public encrypt (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, recipientKeyType?: KeypairType): Uint8Array {
+    return cryptoEncrypt(message, recipientPublicKey, recipientKeyType || this.type);
   }
 }

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -41,15 +41,6 @@ const TYPE_SIGNATURE = {
   sr25519: sr25519Sign
 };
 
-const TYPE_DECRYPTION = {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ecdsa: (m: HexString | string | Uint8Array, p: Partial<Keypair>) => { throw new Error('Secp256k1 not supported yet'); },
-  ed25519: ed25519Decrypt,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ethereum: (m: HexString | string | Uint8Array, p: Partial<Keypair>) => { throw new Error('Secp256k1 not supported yet'); },
-  sr25519: sr25519Decrypt
-};
-
 const TYPE_ADDRESS = {
   ecdsa: (p: Uint8Array) => p.length > 32 ? blake2AsU8a(p) : p,
   ed25519: (p: Uint8Array) => p,
@@ -157,7 +148,9 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
       assert(!isLocked(secretKey), 'Cannot decrypt with a locked key pair');
       assert(!['ecdsa', 'ethereum'].includes(type), 'Secp256k1 not supported yet');
 
-      return TYPE_DECRYPTION[type](u8aToU8a(encryptedMessage), { publicKey, secretKey });
+      return type === 'ed25519'
+        ? ed25519Decrypt(u8aToU8a(encryptedMessage), { publicKey, secretKey })
+        : sr25519Decrypt(u8aToU8a(encryptedMessage), { publicKey, secretKey });
     },
     decryptMessage: (encryptedMessageWithNonce: HexString | string | Uint8Array, senderPublicKey: HexString | string | Uint8Array): Uint8Array | null => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -177,8 +177,11 @@ export function createPair ({ toSS58, type }: Setup, { publicKey, secretKey }: P
     encodePkcs8: (passphrase?: string): Uint8Array => {
       return recode(passphrase);
     },
-    encrypt: (message: HexString | string | Uint8Array): Uint8Array => {
-      return cryptoEncrypt(message, publicKey, type);
+    encrypt: (message: HexString | string | Uint8Array, recipientPublicKey: HexString | string | Uint8Array): Uint8Array => {
+      assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');
+      assert(!['ecdsa', 'ethereum'].includes(type), 'Secp256k1 not supported yet');
+
+      return cryptoEncrypt(message, recipientPublicKey, type, { publicKey, secretKey });
     },
     encryptMessage: (message: HexString | string | Uint8Array, recipientPublicKey: HexString | string | Uint8Array, nonceIn?: Uint8Array): Uint8Array => {
       assert(!isLocked(secretKey), 'Cannot encrypt with a locked key pair');

--- a/packages/keyring/src/pair/nobody.ts
+++ b/packages/keyring/src/pair/nobody.ts
@@ -31,6 +31,9 @@ const pair: KeyringPair = {
   decodePkcs8: (passphrase?: string, encoded?: Uint8Array): void =>
     undefined,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  decrypt: (encryptedMessage: string | Uint8Array): Uint8Array | null =>
+    null,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   decryptMessage: (encryptedMessageWithNonce: string | Uint8Array, senderPublicKey: string | Uint8Array): Uint8Array | null =>
     null,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -39,6 +42,9 @@ const pair: KeyringPair = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   encodePkcs8: (passphrase?: string): Uint8Array =>
     new Uint8Array(0),
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  encrypt: (message: string | Uint8Array): Uint8Array =>
+    new Uint8Array(),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   encryptMessage: (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, _nonce?: Uint8Array): Uint8Array =>
     new Uint8Array(),

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -41,7 +41,7 @@ export interface KeyringPair {
   verify (message: HexString | string | Uint8Array, signature: Uint8Array, signerPublic: HexString | string | Uint8Array): boolean;
   vrfSign (message: HexString | string | Uint8Array, context?: HexString | string | Uint8Array, extra?: HexString | string | Uint8Array): Uint8Array;
   vrfVerify (message: HexString | string | Uint8Array, vrfResult: Uint8Array, signerPublic: HexString | Uint8Array | string, context?: HexString | string | Uint8Array, extra?: HexString | string | Uint8Array): boolean;
-  encrypt (message: HexString | string | Uint8Array): Uint8Array;
+  encrypt (message: HexString | string | Uint8Array, recipientPublicKey: HexString | string | Uint8Array): Uint8Array;
   decrypt (encryptedMessage: HexString | string | Uint8Array): Uint8Array | null;
 }
 

--- a/packages/keyring/src/types.ts
+++ b/packages/keyring/src/types.ts
@@ -41,6 +41,8 @@ export interface KeyringPair {
   verify (message: HexString | string | Uint8Array, signature: Uint8Array, signerPublic: HexString | string | Uint8Array): boolean;
   vrfSign (message: HexString | string | Uint8Array, context?: HexString | string | Uint8Array, extra?: HexString | string | Uint8Array): Uint8Array;
   vrfVerify (message: HexString | string | Uint8Array, vrfResult: Uint8Array, signerPublic: HexString | Uint8Array | string, context?: HexString | string | Uint8Array, extra?: HexString | string | Uint8Array): boolean;
+  encrypt (message: HexString | string | Uint8Array): Uint8Array;
+  decrypt (encryptedMessage: HexString | string | Uint8Array): Uint8Array | null;
 }
 
 export interface KeyringPairs {
@@ -74,4 +76,5 @@ export interface KeyringInstance {
   getPublicKeys (): Uint8Array[];
   removePair (address: string | Uint8Array): void;
   toJson (address: string | Uint8Array, passphrase?: string): KeyringPair$Json;
+  encrypt (message: string | Uint8Array, recipientPublicKey: string | Uint8Array, recipientKeyType?: KeypairType): Uint8Array;
 }

--- a/packages/util-crypto/src/bundle.ts
+++ b/packages/util-crypto/src/bundle.ts
@@ -13,6 +13,7 @@ export * from './base64';
 export * from './blake2';
 export * from './crypto';
 export * from './ed25519';
+export * from './encrypt';
 export * from './ethereum';
 export * from './hd';
 export * from './hmac';

--- a/packages/util-crypto/src/ed25519/decrypt.ts
+++ b/packages/util-crypto/src/ed25519/decrypt.ts
@@ -1,0 +1,44 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HexString } from '@polkadot/util/types';
+import type { Keypair } from '../types';
+
+import nacl from 'tweetnacl';
+
+import { assert, u8aToU8a } from '@polkadot/util';
+
+import { naclOpen } from '..';
+import { convertPublicKeyToCurve25519, convertSecretKeyToCurve25519 } from './convertKey';
+
+interface ed25519EncryptedMessage {
+  ephemeralPublicKey: Uint8Array;
+  nonce: Uint8Array;
+  sealed: Uint8Array;
+}
+
+/**
+ * @name ed25519Decrypt
+ * @description Returns decrypted message of `encryptedMessage`, using the supplied pair
+ */
+export function ed25519Decrypt (encryptedMessage: HexString | Uint8Array | string, { secretKey }: Partial<Keypair>): Uint8Array | null {
+  const decapsulatedEncryptedMessage = ed25519DecapsulateEncryptedMessage(encryptedMessage);
+  const x25519PublicKey = convertPublicKeyToCurve25519(decapsulatedEncryptedMessage.ephemeralPublicKey);
+  const x25519SecretKey = convertSecretKeyToCurve25519(u8aToU8a(secretKey));
+
+  return naclOpen(decapsulatedEncryptedMessage.sealed, decapsulatedEncryptedMessage.nonce, x25519PublicKey, x25519SecretKey);
+}
+
+/**
+ * @name ed25519DecapsulateEncryptedMessage
+ * @description Split raw encrypted message
+ */
+function ed25519DecapsulateEncryptedMessage (encryptedMessage: HexString | Uint8Array | string): ed25519EncryptedMessage {
+  assert(encryptedMessage.length > nacl.box.publicKeyLength + nacl.box.nonceLength + nacl.box.overheadLength, 'Too short encrypted message');
+
+  return {
+    ephemeralPublicKey: u8aToU8a(encryptedMessage.slice(nacl.box.nonceLength, nacl.box.nonceLength + nacl.box.publicKeyLength)),
+    nonce: u8aToU8a(encryptedMessage.slice(0, nacl.box.nonceLength)),
+    sealed: u8aToU8a(encryptedMessage.slice(nacl.box.nonceLength + nacl.box.publicKeyLength))
+  };
+}

--- a/packages/util-crypto/src/ed25519/decrypt.ts
+++ b/packages/util-crypto/src/ed25519/decrypt.ts
@@ -8,7 +8,7 @@ import nacl from 'tweetnacl';
 
 import { assert, u8aToU8a } from '@polkadot/util';
 
-import { naclOpen } from '..';
+import { naclOpen } from '../nacl';
 import { convertPublicKeyToCurve25519, convertSecretKeyToCurve25519 } from './convertKey';
 
 interface ed25519EncryptedMessage {

--- a/packages/util-crypto/src/ed25519/encrypt.ts
+++ b/packages/util-crypto/src/ed25519/encrypt.ts
@@ -1,0 +1,23 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HexString } from '@polkadot/util/types';
+
+import { u8aConcat, u8aToU8a } from '@polkadot/util';
+
+import { naclSeal } from '../nacl/seal';
+import { ed25519PairFromRandom } from './pair/fromRandom';
+import { convertPublicKeyToCurve25519, convertSecretKeyToCurve25519 } from './convertKey';
+
+/**
+ * @name ed25519Encrypt
+ * @description Returns encrypted message of `message`, using the supplied pair
+ */
+export function ed25519Encrypt (message: HexString | Uint8Array | string, publicKey: Uint8Array): Uint8Array {
+  const ephemeralKeyPair = ed25519PairFromRandom();
+  const x25519PublicKey = convertPublicKeyToCurve25519(publicKey);
+  const x25519SecretKey = convertSecretKeyToCurve25519(ephemeralKeyPair.secretKey);
+  const { nonce, sealed } = naclSeal(u8aToU8a(message), x25519SecretKey, x25519PublicKey);
+
+  return u8aConcat(nonce, ephemeralKeyPair.publicKey, sealed);
+}

--- a/packages/util-crypto/src/ed25519/encrypt.ts
+++ b/packages/util-crypto/src/ed25519/encrypt.ts
@@ -6,6 +6,7 @@ import type { HexString } from '@polkadot/util/types';
 import { u8aConcat, u8aToU8a } from '@polkadot/util';
 
 import { naclSeal } from '../nacl/seal';
+import { Keypair } from '../types';
 import { ed25519PairFromRandom } from './pair/fromRandom';
 import { convertPublicKeyToCurve25519, convertSecretKeyToCurve25519 } from './convertKey';
 
@@ -13,11 +14,11 @@ import { convertPublicKeyToCurve25519, convertSecretKeyToCurve25519 } from './co
  * @name ed25519Encrypt
  * @description Returns encrypted message of `message`, using the supplied pair
  */
-export function ed25519Encrypt (message: HexString | Uint8Array | string, publicKey: Uint8Array): Uint8Array {
-  const ephemeralKeyPair = ed25519PairFromRandom();
-  const x25519PublicKey = convertPublicKeyToCurve25519(publicKey);
-  const x25519SecretKey = convertSecretKeyToCurve25519(ephemeralKeyPair.secretKey);
+export function ed25519Encrypt (message: HexString | Uint8Array | string, receiverPublicKey: Uint8Array, senderKeyPair?: Keypair): Uint8Array {
+  const messageKeyPair = senderKeyPair || ed25519PairFromRandom();
+  const x25519PublicKey = convertPublicKeyToCurve25519(receiverPublicKey);
+  const x25519SecretKey = convertSecretKeyToCurve25519(messageKeyPair.secretKey);
   const { nonce, sealed } = naclSeal(u8aToU8a(message), x25519SecretKey, x25519PublicKey);
 
-  return u8aConcat(nonce, ephemeralKeyPair.publicKey, sealed);
+  return u8aConcat(nonce, messageKeyPair.publicKey, sealed);
 }

--- a/packages/util-crypto/src/ed25519/index.ts
+++ b/packages/util-crypto/src/ed25519/index.ts
@@ -12,3 +12,5 @@ export { ed25519PairFromSeed } from './pair/fromSeed';
 export { ed25519PairFromString } from './pair/fromString';
 export { ed25519Sign } from './sign';
 export { ed25519Verify } from './verify';
+export { ed25519Encrypt } from './encrypt';
+export { ed25519Decrypt } from './decrypt';

--- a/packages/util-crypto/src/encrypt/encrypt.ts
+++ b/packages/util-crypto/src/encrypt/encrypt.ts
@@ -1,0 +1,25 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HexString } from '@polkadot/util/types';
+import type { KeypairType } from '../types';
+
+import { assert, u8aToU8a } from '@polkadot/util';
+
+import { ed25519Encrypt } from '../ed25519';
+import { sr25519Encrypt } from '../sr25519';
+
+/**
+ * @name encrypt
+ * @summary Encrypt a message using the given publickey
+ * @description Returns the encrypted message of the given message using the public key.
+ * The encrypted message can be decrypted by the corresponding keypair using keypair.decrypt() method
+ */
+export function encrypt (message: HexString | string | Uint8Array, recipientPublicKey: HexString | string | Uint8Array, recipientKeyType: KeypairType): Uint8Array {
+  assert(!['ecdsa', 'ethereum'].includes(recipientKeyType), 'Secp256k1 not supported yet');
+  const publicKey = u8aToU8a(recipientPublicKey);
+
+  return recipientKeyType === 'ed25519'
+    ? ed25519Encrypt(message, publicKey)
+    : sr25519Encrypt(message, publicKey);
+}

--- a/packages/util-crypto/src/encrypt/encrypt.ts
+++ b/packages/util-crypto/src/encrypt/encrypt.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { KeypairType } from '../types';
+import type { Keypair, KeypairType } from '../types';
 
 import { assert, u8aToU8a } from '@polkadot/util';
 
@@ -15,11 +15,11 @@ import { sr25519Encrypt } from '../sr25519';
  * @description Returns the encrypted message of the given message using the public key.
  * The encrypted message can be decrypted by the corresponding keypair using keypair.decrypt() method
  */
-export function encrypt (message: HexString | string | Uint8Array, recipientPublicKey: HexString | string | Uint8Array, recipientKeyType: KeypairType): Uint8Array {
+export function encrypt (message: HexString | string | Uint8Array, recipientPublicKey: HexString | string | Uint8Array, recipientKeyType: KeypairType, senderKeyPair?: Keypair): Uint8Array {
   assert(!['ecdsa', 'ethereum'].includes(recipientKeyType), 'Secp256k1 not supported yet');
   const publicKey = u8aToU8a(recipientPublicKey);
 
   return recipientKeyType === 'ed25519'
-    ? ed25519Encrypt(message, publicKey)
-    : sr25519Encrypt(message, publicKey);
+    ? ed25519Encrypt(message, publicKey, senderKeyPair)
+    : sr25519Encrypt(message, publicKey, senderKeyPair);
 }

--- a/packages/util-crypto/src/encrypt/index.ts
+++ b/packages/util-crypto/src/encrypt/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export { encrypt } from './encrypt';

--- a/packages/util-crypto/src/sr25519/decrypt.ts
+++ b/packages/util-crypto/src/sr25519/decrypt.ts
@@ -1,0 +1,39 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HexString } from '@polkadot/util/types';
+import type { Keypair } from '../types';
+
+import { u8aToU8a } from '@polkadot/util';
+
+import { naclDecrypt } from '../nacl';
+import { buildSR25519EncryptionKey } from './encrypt';
+
+interface sr25519EncryptedMessage {
+  ephemeralPublicKey: Uint8Array;
+  nonce: Uint8Array;
+  sealed: Uint8Array;
+}
+
+/**
+ * @name sr25519Decrypt
+ * @description Returns decrypted message of `encryptedMessage`, using the supplied pair
+ */
+export function sr25519Decrypt (encryptedMessage: HexString | Uint8Array | string, { secretKey }: Partial<Keypair>): Uint8Array | null {
+  const decapsulatedEncryptedMessage = sr25519DecapsulateEncryptedMessage(u8aToU8a(encryptedMessage));
+  const encryptionKey = buildSR25519EncryptionKey(decapsulatedEncryptedMessage.ephemeralPublicKey, u8aToU8a(secretKey), decapsulatedEncryptedMessage.ephemeralPublicKey);
+
+  return naclDecrypt(decapsulatedEncryptedMessage.sealed, decapsulatedEncryptedMessage.nonce, encryptionKey);
+}
+
+/**
+ * @name sr25519DecapsulateEncryptedMessage
+ * @description Split raw encrypted message
+ */
+function sr25519DecapsulateEncryptedMessage (encryptedMessage: Uint8Array): sr25519EncryptedMessage {
+  return {
+    ephemeralPublicKey: encryptedMessage.slice(24, 24 + 32),
+    nonce: encryptedMessage.slice(0, 24),
+    sealed: encryptedMessage.slice(24 + 32)
+  };
+}

--- a/packages/util-crypto/src/sr25519/decrypt.ts
+++ b/packages/util-crypto/src/sr25519/decrypt.ts
@@ -7,10 +7,8 @@ import type { Keypair } from '../types';
 import { assert, u8aCmp, u8aToU8a } from '@polkadot/util';
 
 import { naclDecrypt } from '../nacl';
-import { buildSR25519EncryptionKey, macData } from './encrypt';
+import { buildSR25519EncryptionKey, keyDerivationSaltSize, macData, nonceSize } from './encrypt';
 
-const nonceSize = 24;
-const keyDerivationSaltSize = 32;
 const publicKeySize = 32;
 const macValueSize = 32;
 

--- a/packages/util-crypto/src/sr25519/encrypt.ts
+++ b/packages/util-crypto/src/sr25519/encrypt.ts
@@ -1,6 +1,34 @@
 // Copyright 2017-2021 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// SR25519 Encryption/Decryption following Elliptic Curve Integrated Encryption Scheme (ECIES)
+// https://cryptobook.nakov.com/asymmetric-key-ciphers/ecies-public-key-encryption
+// Implementation details:
+// The algorithms used were chosen among those already used in this library
+// - 1 - Ephemeral Key generation
+//       Generate new keypair using the wasm sr25519KeypairFromSeed function, with a random seed from
+//       mnemonicGenerate
+// - 2 - Key Agreement
+//       Use wasm sr25519Agree function between the generated ephemeral private key and the recipient public key
+// - 3 - Key Derivation
+//       Use pbkdf2 (random salt is generated, default 2048 rounds) to derive a new secret from the previous step output
+//       The derived secret is split into :
+//       - MAC key (first 32 bytes)
+//       - encryption key (last 32 bytes)
+// - 4 - Encryption
+//       Use nacl.secretbox api symmetric encryption (xsalsa20-poly1305) to encrypt the message
+//       with the encryption key generated at step 3.
+//       A nonce (24 bytes) is randomly generated.
+// - 5 - MAC Generation
+//       HMAC SHA256 (using the MAC key from step 3) of the concatenation of the encryption nonce, ephemeral public key and encrypted message
+//
+// The encrypted message is the concatenation of the following elements :
+// - nonce (24 bytes) : random generated nonce used for the symmetric encryption (step 4)
+// - keyDerivationSalt (32 bytes) : random generated salt used for the key derivation (step 3)
+// - public key (32 bytes): public key of the ephemeral generated keypair (step 1)
+// - macValue (32 bytes): mac value computed at step 5
+// - encrypted (remaining bytes): encrypted message (step 4)
+
 import type { HexString } from '@polkadot/util/types';
 
 import { assert, u8aConcat, u8aToU8a } from '@polkadot/util';
@@ -16,6 +44,10 @@ import { sr25519Agreement } from './agreement';
 
 const encryptionKeySize = 32;
 const macKeySize = 32;
+const derivationKeyRounds = 2048;
+
+export const keyDerivationSaltSize = 32;
+export const nonceSize = 24;
 
 /**
  * @name sr25519Encrypt
@@ -24,7 +56,7 @@ const macKeySize = 32;
 export function sr25519Encrypt (message: HexString | Uint8Array | string, receiverPublicKey: Uint8Array, senderKeyPair?: Keypair): Uint8Array {
   const messageKeyPair = senderKeyPair || generateEphemeralKeypair();
   const { encryptionKey, keyDerivationSalt, macKey } = generateEncryptionKey(messageKeyPair, receiverPublicKey);
-  const { encrypted, nonce } = naclEncrypt(u8aToU8a(message), encryptionKey);
+  const { encrypted, nonce } = naclEncrypt(u8aToU8a(message), encryptionKey, randomAsU8a(nonceSize));
   const macValue = macData(nonce, encrypted, messageKeyPair.publicKey, macKey);
 
   return u8aConcat(nonce, keyDerivationSalt, messageKeyPair.publicKey, macValue, encrypted);
@@ -44,7 +76,7 @@ function generateEncryptionKey (senderKeyPair: Keypair, receiverPublicKey: Uint8
   };
 }
 
-export function buildSR25519EncryptionKey (publicKey: Uint8Array, secretKey: Uint8Array, encryptedMessagePairPublicKey: Uint8Array, salt: Uint8Array = randomAsU8a()) {
+export function buildSR25519EncryptionKey (publicKey: Uint8Array, secretKey: Uint8Array, encryptedMessagePairPublicKey: Uint8Array, salt: Uint8Array = randomAsU8a(keyDerivationSaltSize)) {
   const agreementKey = sr25519Agreement(secretKey, publicKey);
   const masterSecret = u8aConcat(encryptedMessagePairPublicKey, agreementKey);
 
@@ -52,7 +84,7 @@ export function buildSR25519EncryptionKey (publicKey: Uint8Array, secretKey: Uin
 }
 
 function deriveKey (masterSecret: Uint8Array, salt: Uint8Array) {
-  const { password } = pbkdf2Encode(masterSecret, salt);
+  const { password } = pbkdf2Encode(masterSecret, salt, derivationKeyRounds);
 
   assert(password.byteLength >= macKeySize + encryptionKeySize, 'Wrong derived key length');
 

--- a/packages/util-crypto/src/sr25519/encrypt.ts
+++ b/packages/util-crypto/src/sr25519/encrypt.ts
@@ -1,0 +1,46 @@
+// Copyright 2017-2021 @polkadot/util-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HexString } from '@polkadot/util/types';
+
+import { u8aConcat, u8aToU8a } from '@polkadot/util';
+
+import { mnemonicGenerate, mnemonicToMiniSecret } from '../mnemonic';
+import { naclEncrypt } from '../nacl';
+import { pbkdf2Encode } from '../pbkdf2';
+import { sr25519PairFromSeed } from './pair/fromSeed';
+import { sr25519Agreement } from './agreement';
+
+/**
+ * @name sr25519Encrypt
+ * @description Returns encrypted message of `message`, using the supplied pair
+ */
+export function sr25519Encrypt (message: HexString | Uint8Array | string, publicKey: Uint8Array): Uint8Array {
+  const { encryptedMessagePairPublicKey, encryptionKey } = generateNewEncryptionKey(publicKey);
+  const { encrypted, nonce } = naclEncrypt(u8aToU8a(message), encryptionKey);
+
+  return u8aConcat(nonce, encryptedMessagePairPublicKey, encrypted);
+}
+
+function generateNewEncryptionKey (receiverPublicKey: Uint8Array) {
+  const encryptedMessagePair = sr25519PairFromSeed(mnemonicToMiniSecret(mnemonicGenerate()));
+
+  return {
+    encryptedMessagePairPublicKey: encryptedMessagePair.publicKey,
+    encryptionKey: buildSR25519EncryptionKey(receiverPublicKey, encryptedMessagePair.secretKey, encryptedMessagePair.publicKey)
+  };
+}
+
+export function buildSR25519EncryptionKey (publicKey: Uint8Array, secretKey: Uint8Array, encryptedMessagePairPublicKey: Uint8Array) {
+  const agreementKey = sr25519Agreement(secretKey, publicKey);
+  const masterSecret = u8aConcat(encryptedMessagePairPublicKey, agreementKey);
+
+  return deriveKey(masterSecret);
+}
+
+function deriveKey (masterSecret: Uint8Array) {
+  const keySize = 32;
+  const { password } = pbkdf2Encode(masterSecret, masterSecret.slice(0, 32));
+
+  return password.slice(0, keySize);
+}

--- a/packages/util-crypto/src/sr25519/encrypt.ts
+++ b/packages/util-crypto/src/sr25519/encrypt.ts
@@ -3,44 +3,62 @@
 
 import type { HexString } from '@polkadot/util/types';
 
-import { u8aConcat, u8aToU8a } from '@polkadot/util';
+import { assert, u8aConcat, u8aToU8a } from '@polkadot/util';
 
+import { hmacSha256AsU8a } from '../hmac';
 import { mnemonicGenerate, mnemonicToMiniSecret } from '../mnemonic';
 import { naclEncrypt } from '../nacl';
 import { pbkdf2Encode } from '../pbkdf2';
+import { randomAsU8a } from '../random';
 import { sr25519PairFromSeed } from './pair/fromSeed';
 import { sr25519Agreement } from './agreement';
+
+const encryptionKeySize = 32;
+const macKeySize = 32;
 
 /**
  * @name sr25519Encrypt
  * @description Returns encrypted message of `message`, using the supplied pair
  */
 export function sr25519Encrypt (message: HexString | Uint8Array | string, publicKey: Uint8Array): Uint8Array {
-  const { encryptedMessagePairPublicKey, encryptionKey } = generateNewEncryptionKey(publicKey);
+  const { encryptedMessagePairPublicKey, encryptionKey, keyDerivationSalt, macKey } = generateNewEncryptionKey(publicKey);
   const { encrypted, nonce } = naclEncrypt(u8aToU8a(message), encryptionKey);
+  const macValue = macData(nonce, encrypted, encryptedMessagePairPublicKey, macKey);
 
-  return u8aConcat(nonce, encryptedMessagePairPublicKey, encrypted);
+  return u8aConcat(nonce, keyDerivationSalt, encryptedMessagePairPublicKey, macValue, encrypted);
 }
 
 function generateNewEncryptionKey (receiverPublicKey: Uint8Array) {
   const encryptedMessagePair = sr25519PairFromSeed(mnemonicToMiniSecret(mnemonicGenerate()));
+  const { encryptionKey, keyDerivationSalt, macKey } = buildSR25519EncryptionKey(receiverPublicKey, encryptedMessagePair.secretKey, encryptedMessagePair.publicKey);
 
   return {
     encryptedMessagePairPublicKey: encryptedMessagePair.publicKey,
-    encryptionKey: buildSR25519EncryptionKey(receiverPublicKey, encryptedMessagePair.secretKey, encryptedMessagePair.publicKey)
+    encryptionKey,
+    keyDerivationSalt,
+    macKey
   };
 }
 
-export function buildSR25519EncryptionKey (publicKey: Uint8Array, secretKey: Uint8Array, encryptedMessagePairPublicKey: Uint8Array) {
+export function buildSR25519EncryptionKey (publicKey: Uint8Array, secretKey: Uint8Array, encryptedMessagePairPublicKey: Uint8Array, salt: Uint8Array = randomAsU8a()) {
   const agreementKey = sr25519Agreement(secretKey, publicKey);
   const masterSecret = u8aConcat(encryptedMessagePairPublicKey, agreementKey);
 
-  return deriveKey(masterSecret);
+  return deriveKey(masterSecret, salt);
 }
 
-function deriveKey (masterSecret: Uint8Array) {
-  const keySize = 32;
-  const { password } = pbkdf2Encode(masterSecret, masterSecret.slice(0, 32));
+function deriveKey (masterSecret: Uint8Array, salt: Uint8Array) {
+  const { password } = pbkdf2Encode(masterSecret, salt);
 
-  return password.slice(0, keySize);
+  assert(password.byteLength >= macKeySize + encryptionKeySize, 'Wrong derived key length');
+
+  return {
+    encryptionKey: password.slice(macKeySize, macKeySize + encryptionKeySize),
+    keyDerivationSalt: salt,
+    macKey: password.slice(0, macKeySize)
+  };
+}
+
+export function macData (nonce: Uint8Array, encryptedMessage: Uint8Array, encryptedMessagePairPublicKey: Uint8Array, macKey: Uint8Array): Uint8Array {
+  return hmacSha256AsU8a(macKey, u8aConcat(nonce, encryptedMessagePairPublicKey, encryptedMessage));
 }

--- a/packages/util-crypto/src/sr25519/index.ts
+++ b/packages/util-crypto/src/sr25519/index.ts
@@ -10,3 +10,5 @@ export { sr25519Sign } from './sign';
 export { sr25519Verify } from './verify';
 export { sr25519VrfSign } from './vrfSign';
 export { sr25519VrfVerify } from './vrfVerify';
+export { sr25519Encrypt } from './encrypt';
+export { sr25519Decrypt } from './decrypt';


### PR DESCRIPTION
Hi all,

This work is an alternative way to add the asymmetric encryption/decryption feature than the one [already implemented](https://github.com/polkadot-js/common/pull/1070), which [does not work with sr25519](https://github.com/polkadot-js/common/issues/1314) (see [workaround proposal](https://github.com/polkadot-js/common/pull/1320) by @RoyTimes).

It works more like the [eth_decrypt function](https://docs.metamask.io/guide/rpc-api.html#eth-decrypt) from Metamask, where only one public key/private key pair is involved : you can encrypt data with the public key of the recipient, and only this recipient can decrypt the data with his private/secret key (vs the already implemented solution using [nacl.box](https://github.com/dchest/tweetnacl-js#public-key-authenticated-encryption-box) which requires 2 keypairs).

### What has been done ?

- Add `encrypt/decrypt`  methods to `util-crypto\sr25519` following [ECIES](https://cryptobook.nakov.com/asymmetric-key-ciphers/ecies-public-key-encryption)
- Add `encrypt/decrypt` methods to `util-crypto\ed25519` using existing encryption feature, but with an ephemeral key (similar as ECIES)
- Add `encrypt` method to `keyring` (_encrypt data without the need of a keypair_)
- Add `encrypt/decrypt` methods to  `keyringPair`

### Implementation details
Following SR25519 Encryption/Decryption following Elliptic Curve Integrated Encryption Scheme (ECIES)  
See https://cryptobook.nakov.com/asymmetric-key-ciphers/ecies-public-key-encryption

The algorithms used were chosen among those already used in this library.

1. **Ephemeral Key generation**
      Generate new keypair using the wasm `sr25519KeypairFromSeed` function, with a random seed from
      `mnemonicGenerate`
2. **Key Agreement**
      Use wasm `sr25519Agree` function between the generated ephemeral private key and the recipient public key
3. **Key Derivation**
      Use `pbkdf2` (random salt is generated, default 2048 rounds) to derive a new secret from the previous step output
      The derived secret is split into :
      - MAC key (first 32 bytes)
      - encryption key (last 32 bytes)
4. **Encryption**
      Use `nacl.secretbox` api symmetric encryption (xsalsa20-poly1305) to encrypt the message
      with the encryption key generated at step 3.
      A nonce (24 bytes) is randomly generated.
5. **MAC Generation**
      HMAC SHA256 (using the MAC key from step 3) of the concatenation of the encryption nonce, ephemeral public key and encrypted message

The encrypted message is the concatenation of the following elements :
- nonce (24 bytes) : random generated nonce used for the symmetric encryption (step 4)
- keyDerivationSalt (32 bytes) : random generated salt used for the key derivation (step 3)
- public key (32 bytes): public key of the ephemeral generated keypair (step 1)
- macValue (32 bytes): mac value computed at step 5
- encrypted (remaining bytes): encrypted message (step 4)

---
Feel free to share your comments and feedbacks :pray: 

**Nota :** Some folks were interested in this feature:
- [Asymmetric encryption and decryption support](https://github.com/polkadot-js/common/issues/633)
- [Public key / Private key encryption using polkadot lib?](https://github.com/polkadot-js/common/issues/929)
- [Feature Request: Asymmetric Encryption](https://github.com/polkadot-js/extension/issues/691)