### PR TITLE
Use global `crypto` object for browser and `webcrypto` for Node.js

### DIFF
--- a/packages/x-bundle/package.json
+++ b/packages/x-bundle/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.16.7",
     "@polkadot/util": "8.2.3-18",
+    "@polkadot/x-global": "8.2.3-18",
     "buffer-es6": "^4.9.3"
   }
 }

--- a/packages/x-bundle/src/crypto.ts
+++ b/packages/x-bundle/src/crypto.ts
@@ -1,4 +1,12 @@
 // Copyright 2017-2022 @polkadot/x-bundle authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export default {};
+import { xglobal } from '@polkadot/x-global';
+
+let crypto = xglobal.crypto;
+
+if (crypto === undefined && typeof require === 'function') {
+	crypto = require('crypto').webcrypto;
+}
+
+export default crypto;

--- a/packages/x-bundle/tsconfig.json
+++ b/packages/x-bundle/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "./src"
   },
   "references": [
-    { "path": "../util" }
+    { "path": "../util" },
+    { "path": "../x-global" }
   ]
 }


### PR DESCRIPTION
This pull request will fix the key pair's signer when using `polkadotApi.Keyring` with `sr25519`.

For referencing about the error:
https://jsbin.com/cewajinaro/edit?html,js,console

```js
let keyring = new polkadotApi.Keyring({
  type: 'sr25519'
});

!async function(){
  await polkadotUtilCrypto.cryptoWaitReady();

  let dummy = window.crypto.getRandomValues(new Uint8Array(32));
  let pair = keyring.addFromSeed(dummy);
  
  let result = pair.sign("Hello"); // throw error: crypto$1.getRandomValues is not a function
  console.log(result);
}();
```