### PR TITLE
Add xxnetwork genesis hash and ledger app

### DIFF
--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -4,7 +4,7 @@
 import type Transport from '@ledgerhq/hw-transport';
 import type { SubstrateApp } from '@zondax/ledger-substrate';
 
-import { newBifrostApp, newCentrifugeApp, newDockApp, newEdgewareApp, newEquilibriumApp, newGenshiroApp, newKusamaApp, newNodleApp, newPolkadotApp, newPolymeshApp, newSoraApp, newStatemineApp } from '@zondax/ledger-substrate';
+import { newBifrostApp, newCentrifugeApp, newDockApp, newEdgewareApp, newEquilibriumApp, newGenshiroApp, newKusamaApp, newNodleApp, newPolkadotApp, newPolymeshApp, newSoraApp, newStatemineApp, newXXNetworkApp } from '@zondax/ledger-substrate';
 
 // These match up with the keys of the knownLedger object in the @polkadot/networks/defaults/ledger.ts
 export const ledgerApps: Record<string, (transport: Transport) => SubstrateApp> = {
@@ -19,5 +19,6 @@ export const ledgerApps: Record<string, (transport: Transport) => SubstrateApp> 
   polkadot: newPolkadotApp,
   polymesh: newPolymeshApp,
   sora: newSoraApp,
-  statemine: newStatemineApp
+  statemine: newStatemineApp,
+  xxnetwork: newXXNetworkApp
 };

--- a/packages/networks/src/defaults/genesis.ts
+++ b/packages/networks/src/defaults/genesis.ts
@@ -92,5 +92,8 @@ export const knownGenesis: KnownGenesis = {
   ],
   westend: [
     '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e'
+  ],
+  xxnetwork: [
+    '0x50dd5d206917bf10502c68fb4d18a59fc8aa31586f4e8856b493e43544aa82aa'
   ]
 };

--- a/packages/networks/src/defaults/ledger.ts
+++ b/packages/networks/src/defaults/ledger.ts
@@ -19,5 +19,6 @@ export const knownLedger: KnownLedger = {
   polkadot: 0x00000162,
   polymesh: 0x00000253,
   sora: 0x00000269,
-  statemine: 0x000001b2 // common-good on Kusama, shares derivation
+  statemine: 0x000001b2, // common-good on Kusama, shares derivation
+  xxnetwork: 0x000007a3
 };


### PR DESCRIPTION
This PR adds [xxnetwork](https://xx.network) to known networks, including Ledger app support.