### PR TITLE
some changes to KnownLedger

### DIFF
--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -18,6 +18,7 @@ export const ledgerApps: Record<string, (transport: Transport) => SubstrateApp> 
   karura: newKaruraApp,
   kusama: newKusamaApp,
   'nodle-chain': newNodleApp,
+  'nodle-para': newNodleApp,
   parallel: newParallelApp,
   polkadot: newPolkadotApp,
   polymesh: newPolymeshApp,

--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -4,11 +4,12 @@
 import type Transport from '@ledgerhq/hw-transport';
 import type { SubstrateApp } from '@zondax/ledger-substrate';
 
-import { newAcalaApp, newBifrostApp, newCentrifugeApp, newDockApp, newEdgewareApp, newEquilibriumApp, newGenshiroApp, newKaruraApp, newKusamaApp, newNodleApp, newParallelApp, newPolkadotApp, newPolymeshApp, newSoraApp, newStatemineApp, newStatemintApp, newXXNetworkApp } from '@zondax/ledger-substrate';
+import { newAcalaApp, newAstarApp, newBifrostApp, newCentrifugeApp, newDockApp, newEdgewareApp, newEquilibriumApp, newGenshiroApp, newKaruraApp, newKusamaApp, newNodleApp, newParallelApp, newPolkadexApp, newPolkadotApp, newPolymeshApp, newSoraApp, newStatemineApp, newStatemintApp, newXXNetworkApp } from '@zondax/ledger-substrate';
 
 // These match up with the keys of the knownLedger object in the @polkadot/networks/defaults/ledger.ts
 export const ledgerApps: Record<string, (transport: Transport) => SubstrateApp> = {
   acala: newAcalaApp,
+  astar: newAstarApp,
   bifrost: newBifrostApp,
   centrifuge: newCentrifugeApp,
   'dock-mainnet': newDockApp,
@@ -20,6 +21,7 @@ export const ledgerApps: Record<string, (transport: Transport) => SubstrateApp> 
   'nodle-chain': newNodleApp,
   'nodle-para': newNodleApp,
   parallel: newParallelApp,
+  polkadex: newPolkadexApp,
   polkadot: newPolkadotApp,
   polymesh: newPolymeshApp,
   sora: newSoraApp,

--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -18,7 +18,6 @@ export const ledgerApps: Record<string, (transport: Transport) => SubstrateApp> 
   genshiro: newGenshiroApp,
   karura: newKaruraApp,
   kusama: newKusamaApp,
-  'nodle-chain': newNodleApp,
   'nodle-para': newNodleApp,
   parallel: newParallelApp,
   polkadex: newPolkadexApp,

--- a/packages/networks/src/defaults/genesis.ts
+++ b/packages/networks/src/defaults/genesis.ts
@@ -53,9 +53,6 @@ export const knownGenesis: KnownGenesis = {
     '0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636', // Kusama CC2
     '0x3fd7b9eb6a00376e5be61f01abb429ffb0b104be05eaff4d458da48fcd425baf' // Kusama CC1
   ],
-  'nodle-chain': [
-    '0xa3d114c2b8d0627c1aa9b134eafcf7d05ca561fdc19fb388bb9457f81809fb23'
-  ],
   'nodle-para': [
     '0x97da7ede98d7bad4e36b4d734b6055425a3be036da2a332ea5a7037656427a21'
   ],

--- a/packages/networks/src/defaults/genesis.ts
+++ b/packages/networks/src/defaults/genesis.ts
@@ -65,6 +65,9 @@ export const knownGenesis: KnownGenesis = {
   picasso: [
     '0xe8e7f0f4c4f5a00720b4821dbfddefea7490bcf0b19009961cc46957984e2c1c'
   ],
+  polkadex: [
+    '0x3920bcb4960a1eef5580cd5367ff3f430eef052774f78468852f7b9cb39f8a3c'
+  ],
   polkadot: [
     '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3'
   ],

--- a/packages/networks/src/defaults/genesis.ts
+++ b/packages/networks/src/defaults/genesis.ts
@@ -56,6 +56,9 @@ export const knownGenesis: KnownGenesis = {
   'nodle-chain': [
     '0xa3d114c2b8d0627c1aa9b134eafcf7d05ca561fdc19fb388bb9457f81809fb23'
   ],
+  'nodle-para': [
+    '0x97da7ede98d7bad4e36b4d734b6055425a3be036da2a332ea5a7037656427a21'
+  ],
   parallel: [
     '0xe61a41c53f5dcd0beb09df93b34402aada44cb05117b71059cce40a2723a4e97'
   ],

--- a/packages/networks/src/defaults/ledger.ts
+++ b/packages/networks/src/defaults/ledger.ts
@@ -18,7 +18,6 @@ export const knownLedger: KnownLedger = {
   genshiro: 0x05f5e0fc,
   karura: 0x000002ae,
   kusama: 0x000001b2,
-  'nodle-chain': 0x000003eb,
   'nodle-para': 0x000003eb,
   parallel: 0x00000162,
   polkadex: 0x0000031f,

--- a/packages/networks/src/defaults/ledger.ts
+++ b/packages/networks/src/defaults/ledger.ts
@@ -9,6 +9,7 @@ import type { KnownLedger } from '../types';
 // NOTE: Any network here needs to have a genesisHash attached in the ./genesis.ts config
 export const knownLedger: KnownLedger = {
   acala: 0x00000313,
+  astar: 0x0000032a,
   bifrost: 0x00000314,
   centrifuge: 0x000002eb,
   'dock-mainnet': 0x00000252,
@@ -20,6 +21,7 @@ export const knownLedger: KnownLedger = {
   'nodle-chain': 0x000003eb,
   'nodle-para': 0x000003eb,
   parallel: 0x00000162,
+  polkadex: 0x0000031f,
   polkadot: 0x00000162,
   polymesh: 0x00000253,
   sora: 0x00000269,

--- a/packages/networks/src/defaults/ledger.ts
+++ b/packages/networks/src/defaults/ledger.ts
@@ -18,6 +18,7 @@ export const knownLedger: KnownLedger = {
   karura: 0x000002ae,
   kusama: 0x000001b2,
   'nodle-chain': 0x000003eb,
+  'nodle-para': 0x000003eb,
   parallel: 0x00000162,
   polkadot: 0x00000162,
   polymesh: 0x00000253,


### PR DESCRIPTION
I list the changes here:
- Nodle has changed chain, now with a new parachain. I added it but I left the other one, just for compatibility some time. It should be removed in some time. EDIT: I asked the team and they confirmed that the old chain has been halted, so I removed it from those files.
- I added Astar and Polkadex to KnownLedger

I just have one doubt. The name of the keys (so `astar`, `nodle-para`, `nodle-chain`) is the name that I can see in polkadot.js.org/apps at the left side, just below the name, right? So `<name>/<spec version>`? In this case polkadex name is `node` that probably is so general, but I added a comment to recognize it.
Thanks!