### PR TITLE
Adjust has{Buffer, Process} checks w/ globalThis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## master
+
+Contributed:
+
+- Ledger support for Ajuna (Thanks to https://github.com/carlosala)
+
+Changes:
+
+- `has{Buffer, Process}` now checks on `globalThis` (helps bundlers with auto-injection)
+
+
 ## 10.1.14 Nov 27, 2022
 
 Changes:

--- a/packages/util/src/has.spec.ts
+++ b/packages/util/src/has.spec.ts
@@ -1,0 +1,10 @@
+// Copyright 2017-2022 @polkadot/util authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { hasBuffer } from './has';
+
+describe('hasBuffer', (): void => {
+  it('has Buffer (Jest + Node.js)', (): void => {
+    expect(hasBuffer).toEqual(typeof Buffer !== 'undefined');
+  });
+});

--- a/packages/util/src/has.ts
+++ b/packages/util/src/has.ts
@@ -2,21 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BigInt } from '@polkadot/x-bigint';
+import { xglobal } from '@polkadot/x-global';
 
 // Since we run in very different environments, we have to ensure we have all
 // the types used here for detection (some of these may require Node definitions,
 // which are not available in Deno/browser)
 declare const __dirname: unknown;
-declare const Buffer: unknown;
 declare const module: unknown;
-declare const process: unknown;
 declare const require: unknown;
 
 /** true if the environment has proper BigInt support */
 export const hasBigInt = typeof BigInt === 'function' && typeof BigInt.asIntN === 'function';
-
-/** true if the environment has support for Buffer */
-export const hasBuffer = typeof Buffer !== 'undefined';
 
 /** true if the environment is CJS */
 export const hasCjs = typeof require === 'function' && typeof module !== 'undefined';
@@ -27,8 +23,14 @@ export const hasDirname = typeof __dirname !== 'undefined';
 /** true if the environment is ESM */
 export const hasEsm = !hasCjs;
 
-/** true if the environment has process available (typically Node.js) */
-export const hasProcess = typeof process === 'object';
-
 /** true if the environment has WebAssembly available */
 export const hasWasm = typeof WebAssembly !== 'undefined';
+
+// NOTE We check the following on globalThis, avoiding specific polyfill detection
+// that some bundlers such as parcel would add (this is a check, not a use)
+
+/** true if the environment has support for Buffer (typically Node.js) */
+export const hasBuffer = typeof xglobal.Buffer !== 'undefined';
+
+/** true if the environment has process available (typically Node.js) */
+export const hasProcess = typeof xglobal.process === 'object';

--- a/packages/util/src/logger.ts
+++ b/packages/util/src/logger.ts
@@ -3,6 +3,8 @@
 
 import type { Logger, Logger$Data } from './types';
 
+import { xglobal } from '@polkadot/x-global';
+
 import { formatDate } from './format/formatDate';
 import { isBn } from './is/bn';
 import { isBuffer } from './is/buffer';
@@ -12,8 +14,6 @@ import { isU8a } from './is/u8a';
 import { u8aToHex } from './u8a/toHex';
 import { u8aToU8a } from './u8a/toU8a';
 import { hasProcess } from './has';
-
-declare const process: { env: Record<string, string> };
 
 type ConsoleType = 'error' | 'log' | 'warn';
 type LogType = ConsoleType | 'debug';
@@ -124,7 +124,7 @@ function getDebugFlag (env: readonly string[], type: string): boolean {
 }
 
 function parseEnv (type: string): [boolean, number] {
-  const env = (hasProcess ? process : {}).env || {};
+  const env = (hasProcess ? xglobal.process as { env: Record<string, string> } : {}).env || {};
   const maxSize = parseInt(env.DEBUG_MAX || '-1', 10);
 
   return [


### PR DESCRIPTION
As per https://github.com/polkadot-js/api/issues/5359 having the naked checks trips up some bundlers and they would auto-add the Buffer or process polyfills. (These are not needed for operation, the detection is there to enable specific features)