### PR TITLE
fix Nodle's known network name

### DIFF
--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -22,7 +22,7 @@ export const ledgerApps: Record<string, string> = {
   karura: 'Karura',
   khala: 'Khala',
   kusama: 'Kusama',
-  'nodle-para': 'Nodle',
+  nodle: 'Nodle',
   origintrail: 'OriginTrail',
   parallel: 'Parallel',
   phala: 'Phala',

--- a/packages/networks/src/defaults/genesis.ts
+++ b/packages/networks/src/defaults/genesis.ts
@@ -76,7 +76,7 @@ export const knownGenesis: KnownGenesis = {
     '0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636', // Kusama CC2
     '0x3fd7b9eb6a00376e5be61f01abb429ffb0b104be05eaff4d458da48fcd425baf' // Kusama CC1
   ],
-  'nodle-para': [
+  nodle: [
     '0x97da7ede98d7bad4e36b4d734b6055425a3be036da2a332ea5a7037656427a21'
   ],
   origintrail: [

--- a/packages/networks/src/defaults/ledger.ts
+++ b/packages/networks/src/defaults/ledger.ts
@@ -26,7 +26,7 @@ export const knownLedger: KnownLedger = {
   karura: 0x000002ae,
   khala: 0x000001b2,
   kusama: 0x000001b2,
-  'nodle-para': 0x000003eb,
+  nodle: 0x000003eb,
   origintrail: 0x00000162,
   parallel: 0x00000162,
   phala: 0x00000162,


### PR DESCRIPTION
Nodle's known network name in [ss58-registry.json](https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json) is "nodle". In contrast "nodle-para" is the runtime's spec name shared between nodle's main parachain on Polkadot and nodle's test parachain on Rococo. This change is necessary for the logic in [networks/src/interfaces.ts](https://github.com/polkadot-js/common/blob/master/packages/networks/src/interfaces.ts) to flag Nodle as a selectable network to interact with Ledger. This issue is impacting polkadot-js/apps in not listing Nodle in the modal dialog for creating a new Ledger account.
This fix needs to be checked by @carlosala in case it may have any side-effect on the actual function of connecting to Nodle's app on Ledger.