### PR TITLE
Align tsconfig to allow moduleResolution: nodenext

### DIFF
--- a/packages/hw-ledger-transports/src/browser.ts
+++ b/packages/hw-ledger-transports/src/browser.ts
@@ -1,23 +1,23 @@
 // Copyright 2017-2023 @polkadot/hw-ledger authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type Transport from '@ledgerhq/hw-transport';
-import type { TransportDef } from './types';
+import type { Transport, TransportDef } from './types.js';
 
 import LedgerWebHid from '@ledgerhq/hw-transport-webhid';
 import LedgerWebUsb from '@ledgerhq/hw-transport-webusb';
 
 export { packageInfo } from './packageInfo.js';
 
+// See usage of Transport interface in types.ts
 export const transports: TransportDef[] = [
   {
     create: (): Promise<Transport> =>
-      LedgerWebUsb.create(),
+      (LedgerWebUsb as unknown as Transport).create(),
     type: 'webusb'
   },
   {
     create: (): Promise<Transport> =>
-      LedgerWebHid.create(),
+      (LedgerWebHid as unknown as Transport).create(),
     type: 'hid'
   }
 ];

--- a/packages/hw-ledger-transports/src/node.ts
+++ b/packages/hw-ledger-transports/src/node.ts
@@ -1,17 +1,17 @@
 // Copyright 2017-2023 @polkadot/hw-ledger authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type Transport from '@ledgerhq/hw-transport';
-import type { TransportDef } from './types';
+import type { Transport, TransportDef } from './types.js';
 
 import LedgerHid from '@ledgerhq/hw-transport-node-hid-singleton';
 
 export { packageInfo } from './packageInfo.js';
 
+// See usage of Transport interface in types.ts
 export const transports: TransportDef[] = [
   {
     create: (): Promise<Transport> =>
-      LedgerHid.create(),
+      (LedgerHid as unknown as Transport).create(),
     type: 'hid'
   }
 ];

--- a/packages/hw-ledger-transports/src/types.ts
+++ b/packages/hw-ledger-transports/src/types.ts
@@ -1,9 +1,17 @@
 // Copyright 2017-2023 @polkadot/hw-ledger authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import Transport from '@ledgerhq/hw-transport';
-
 export type LedgerTypes = 'hid' | 'u2f' | 'webusb';
+
+// The actual namespaced Transport interface (as detailed on the next line)
+//
+//   import type Transport from '@ledgerhq/hw-transport';
+//
+// does not quite work on moduleResolution: nodenext, so we just go with a
+// very light interface here
+export interface Transport {
+  create (): Promise<Transport>;
+}
 
 export interface TransportDef {
   /** Create a transport to be used in Ledger operations */

--- a/packages/keyring/src/index.spec.ts
+++ b/packages/keyring/src/index.spec.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="@polkadot/dev/node/test/node" />
 
-import type { KeyringPair$Json } from './types';
+import type { KeyringPair$Json } from './types.js';
 
 import { hexToU8a, stringToU8a } from '@polkadot/util';
 import { base64Decode, cryptoWaitReady, encodeAddress, randomAsU8a, setSS58Format } from '@polkadot/util-crypto';

--- a/packages/keyring/src/keyring.ts
+++ b/packages/keyring/src/keyring.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { EncryptedJsonEncoding, Keypair, KeypairType } from '@polkadot/util-crypto/types';
-import type { KeyringInstance, KeyringOptions, KeyringPair, KeyringPair$Json, KeyringPair$Meta } from './types';
+import type { KeyringInstance, KeyringOptions, KeyringPair, KeyringPair$Json, KeyringPair$Meta } from './types.js';
 
 import { hexToU8a, isHex, stringToU8a } from '@polkadot/util';
 import { base64Decode, decodeAddress, ed25519PairFromSeed as ed25519FromSeed, encodeAddress, ethereumEncode, hdEthereum, keyExtractSuri, keyFromPath, mnemonicToLegacySeed, mnemonicToMiniSecret, secp256k1PairFromSeed as secp256k1FromSeed, sr25519PairFromSeed as sr25519FromSeed } from '@polkadot/util-crypto';

--- a/packages/keyring/src/pair/decode.ts
+++ b/packages/keyring/src/pair/decode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { EncryptedJsonEncoding } from '@polkadot/util-crypto/types';
-import type { PairInfo } from './types';
+import type { PairInfo } from './types.js';
 
 import { u8aEq } from '@polkadot/util';
 import { jsonDecryptData } from '@polkadot/util-crypto';

--- a/packages/keyring/src/pair/encode.ts
+++ b/packages/keyring/src/pair/encode.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/keyring authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { PairInfo } from './types';
+import type { PairInfo } from './types.js';
 
 import { u8aConcat } from '@polkadot/util';
 import { naclEncrypt, scryptEncode, scryptToU8a } from '@polkadot/util-crypto';

--- a/packages/keyring/src/pair/index.ts
+++ b/packages/keyring/src/pair/index.ts
@@ -4,7 +4,7 @@
 import type { HexString } from '@polkadot/util/types';
 import type { EncryptedJsonEncoding, Keypair, KeypairType } from '@polkadot/util-crypto/types';
 import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta, SignOptions } from '../types.js';
-import type { PairInfo } from './types';
+import type { PairInfo } from './types.js';
 
 import { objectSpread, u8aConcat, u8aEmpty, u8aEq, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { blake2AsU8a, convertPublicKeyToCurve25519, convertSecretKeyToCurve25519, ed25519PairFromSeed as ed25519FromSeed, ed25519Sign, ethereumEncode, keccakAsU8a, keyExtractPath, keyFromPath, naclOpen, naclSeal, secp256k1Compress, secp256k1Expand, secp256k1PairFromSeed as secp256k1FromSeed, secp256k1Sign, signatureVerify, sr25519PairFromSeed as sr25519FromSeed, sr25519Sign, sr25519VrfSign, sr25519VrfVerify } from '@polkadot/util-crypto';

--- a/packages/keyring/src/pairs.ts
+++ b/packages/keyring/src/pairs.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { KeyringPair, KeyringPairs } from './types';
+import type { KeyringPair, KeyringPairs } from './types.js';
 
 import { isHex, isU8a, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';

--- a/packages/keyring/src/testing.ts
+++ b/packages/keyring/src/testing.ts
@@ -3,7 +3,7 @@
 
 import type { HexString } from '@polkadot/util/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
-import type { KeyringInstance, KeyringOptions } from './types';
+import type { KeyringInstance, KeyringOptions } from './types.js';
 
 import { hexToU8a } from '@polkadot/util';
 

--- a/packages/keyring/src/testingPairs.ts
+++ b/packages/keyring/src/testingPairs.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/keyring authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { KeyringOptions, KeyringPair } from './types';
+import type { KeyringOptions, KeyringPair } from './types.js';
 
 import { nobody } from './pair/nobody.js';
 import { createTestKeyring } from './testing.js';

--- a/packages/util-crypto/src/address/check.ts
+++ b/packages/util-crypto/src/address/check.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 import { base58Decode } from '../base58/index.js';
 import { checkAddressChecksum } from './checksum.js';

--- a/packages/util-crypto/src/address/decode.ts
+++ b/packages/util-crypto/src/address/decode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 // Original implementation: https://github.com/paritytech/polka-ui/blob/4858c094684769080f5811f32b081dd7780b0880/src/polkadot.js#L6
 import { isHex, isU8a, u8aToU8a } from '@polkadot/util';

--- a/packages/util-crypto/src/address/derive.ts
+++ b/packages/util-crypto/src/address/derive.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { DeriveJunction } from '../key/DeriveJunction';
-import type { Prefix } from './types';
+import type { DeriveJunction } from '../key/DeriveJunction.js';
+import type { Prefix } from './types.js';
 
 import { keyExtractPath } from '../key/index.js';
 import { sr25519DerivePublic } from '../sr25519/index.js';

--- a/packages/util-crypto/src/address/encode.ts
+++ b/packages/util-crypto/src/address/encode.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 // Original implementation: https://github.com/paritytech/polka-ui/blob/4858c094684769080f5811f32b081dd7780b0880/src/polkadot.js#L34
 import { u8aConcat } from '@polkadot/util';

--- a/packages/util-crypto/src/address/encodeDerived.ts
+++ b/packages/util-crypto/src/address/encodeDerived.ts
@@ -3,7 +3,7 @@
 
 import type { BN } from '@polkadot/util';
 import type { HexString } from '@polkadot/util/types';
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 import { decodeAddress } from './decode.js';
 import { encodeAddress } from './encode.js';

--- a/packages/util-crypto/src/address/encodeMulti.ts
+++ b/packages/util-crypto/src/address/encodeMulti.ts
@@ -3,7 +3,7 @@
 
 import type { BN } from '@polkadot/util';
 import type { HexString } from '@polkadot/util/types';
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 import { encodeAddress } from './encode.js';
 import { createKeyMulti } from './keyMulti.js';

--- a/packages/util-crypto/src/address/evmToAddress.ts
+++ b/packages/util-crypto/src/address/evmToAddress.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { HashType } from '../secp256k1/types';
-import type { Prefix } from './types';
+import type { HashType } from '../secp256k1/types.js';
+import type { Prefix } from './types.js';
 
 import { u8aConcat } from '@polkadot/util';
 

--- a/packages/util-crypto/src/address/is.ts
+++ b/packages/util-crypto/src/address/is.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 import { validateAddress } from './validate.js';
 

--- a/packages/util-crypto/src/address/setSS58Format.ts
+++ b/packages/util-crypto/src/address/setSS58Format.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 import { logger } from '@polkadot/util';
 

--- a/packages/util-crypto/src/address/sort.ts
+++ b/packages/util-crypto/src/address/sort.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 import { u8aSorted } from '@polkadot/util';
 

--- a/packages/util-crypto/src/address/validate.ts
+++ b/packages/util-crypto/src/address/validate.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { Prefix } from './types';
+import type { Prefix } from './types.js';
 
 import { decodeAddress } from './decode.js';
 

--- a/packages/util-crypto/src/json/constants.ts
+++ b/packages/util-crypto/src/json/constants.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { EncryptedJsonEncoding, EncryptedJsonVersion } from './types';
+import type { EncryptedJsonEncoding, EncryptedJsonVersion } from './types.js';
 
 export const ENCODING: EncryptedJsonEncoding[] = ['scrypt', 'xsalsa20-poly1305'];
 export const ENCODING_NONE: EncryptedJsonEncoding[] = ['none'];

--- a/packages/util-crypto/src/json/decrypt.ts
+++ b/packages/util-crypto/src/json/decrypt.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { EncryptedJson } from './types';
+import type { EncryptedJson } from './types.js';
 
 import { hexToU8a, isHex } from '@polkadot/util';
 

--- a/packages/util-crypto/src/json/decryptData.ts
+++ b/packages/util-crypto/src/json/decryptData.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { EncryptedJsonEncoding } from './types';
+import type { EncryptedJsonEncoding } from './types.js';
 
 import { stringToU8a, u8aFixLength } from '@polkadot/util';
 

--- a/packages/util-crypto/src/json/encrypt.ts
+++ b/packages/util-crypto/src/json/encrypt.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { EncryptedJson } from './types';
+import type { EncryptedJson } from './types.js';
 
 import { u8aConcat } from '@polkadot/util';
 

--- a/packages/util-crypto/src/json/encryptFormat.ts
+++ b/packages/util-crypto/src/json/encryptFormat.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { EncryptedJson } from './types';
+import type { EncryptedJson } from './types.js';
 
 import { base64Encode } from '../base64/index.js';
 import { ENCODING, ENCODING_NONE, ENCODING_VERSION } from './constants.js';

--- a/packages/util/src/test/performance.ts
+++ b/packages/util/src/test/performance.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/util authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-/// <reference types="@polkadot/dev/node/test/node.d.ts" />
+/// <reference types="@polkadot/dev/node/test/node" />
 
 import { formatDecimal, formatNumber } from '../index.js';
 

--- a/packages/util/src/test/performance.ts
+++ b/packages/util/src/test/performance.ts
@@ -1,6 +1,8 @@
 // Copyright 2017-2023 @polkadot/util authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/// <reference types="@polkadot/dev/node/test/node.d.ts" />
+
 import { formatDecimal, formatNumber } from '../index.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,6 @@
       "@polkadot/hw-ledger-transports/*": ["hw-ledger-transports/src/browser.ts"],
       "@polkadot/keyring": ["keyring/src/index.ts"],
       "@polkadot/keyring/packageInfo": ["keyring/src/packageInfo.ts"],
-      "@polkadot/keyring/*": ["keyring/src/*"],
       "@polkadot/networks": ["networks/src/index.ts"],
       "@polkadot/networks/packageInfo": ["networks/src/packageInfo.ts"],
       "@polkadot/util-crypto": ["util-crypto/src/index.ts"],


### PR DESCRIPTION
Follow-up for https://github.com/polkadot-js/api/issues/5524 (when we finally enable `"moduleResolution": "nodenext"` in `@polkadot/dev`)