### PR TITLE
Allow empty string as valid base32/base58/base64 decoder input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Contributed:
 
 Changes:
 
+- Allow empty string as valid base32/base58/base64 decoder input (yields empty)
 - Add additional/missing `/*#__PURE__*/` annotations
 - Upgrade dependencies to latest stable versions
 

--- a/packages/util-crypto/src/base32/decode.spec.ts
+++ b/packages/util-crypto/src/base32/decode.spec.ts
@@ -8,6 +8,14 @@ import { u8aToString } from '@polkadot/util';
 import { base32Decode } from './index.js';
 
 describe('base32Decode', (): void => {
+  it('decodes an empty string)', (): void => {
+    expect(
+      u8aToString(
+        base32Decode('')
+      )
+    ).toEqual('');
+  });
+
   it('decodes a base32', (): void => {
     expect(
       u8aToString(

--- a/packages/util-crypto/src/base32/helpers.ts
+++ b/packages/util-crypto/src/base32/helpers.ts
@@ -65,11 +65,9 @@ export function createIs (validate: ValidateFn): ValidateFn {
 /** @internal */
 export function createValidate ({ chars, ipfs, type }: Config): ValidateFn {
   return (value?: unknown, ipfsCompat?: boolean): value is string => {
-    if (!value || typeof value !== 'string') {
-      throw new Error(`Expected non-null, non-empty ${type} string input`);
-    }
-
-    if (ipfs && ipfsCompat && value[0] !== ipfs) {
+    if (typeof value !== 'string') {
+      throw new Error(`Expected ${type} string input`);
+    } else if (ipfs && ipfsCompat && value[0] !== ipfs) {
       throw new Error(`Expected ipfs-compatible ${type} to start with '${ipfs}'`);
     }
 

--- a/packages/util-crypto/src/base32/helpers.ts
+++ b/packages/util-crypto/src/base32/helpers.ts
@@ -25,12 +25,12 @@ type DecodeFn = (value: string, ipfsCompat?: boolean) => Uint8Array;
 
 type EncodeFn = (value: U8aLike, ipfsCompat?: boolean) => string;
 
-type ValidateFn = (value?: unknown, ipfsCompat?: boolean) => value is string;
+type ValidateFn = (value?: unknown, ipfsCompat?: boolean, allowEmpty?: boolean) => value is string;
 
 /** @internal */
 export function createDecode ({ coder, ipfs }: Config, validate: ValidateFn): DecodeFn {
   return (value: string, ipfsCompat?: boolean): Uint8Array => {
-    validate(value, ipfsCompat);
+    validate(value, ipfsCompat, true);
 
     return coder.decode(
       ipfs && ipfsCompat
@@ -64,8 +64,8 @@ export function createIs (validate: ValidateFn): ValidateFn {
 
 /** @internal */
 export function createValidate ({ chars, ipfs, type }: Config): ValidateFn {
-  return (value?: unknown, ipfsCompat?: boolean): value is string => {
-    if (typeof value !== 'string') {
+  return (value?: unknown, ipfsCompat?: boolean, allowEmpty?: boolean): value is string => {
+    if (typeof value !== 'string' || (!value && !allowEmpty)) {
       throw new Error(`Expected ${type} string input`);
     } else if (ipfs && ipfsCompat && value[0] !== ipfs) {
       throw new Error(`Expected ipfs-compatible ${type} to start with '${ipfs}'`);

--- a/packages/util-crypto/src/base32/helpers.ts
+++ b/packages/util-crypto/src/base32/helpers.ts
@@ -25,12 +25,12 @@ type DecodeFn = (value: string, ipfsCompat?: boolean) => Uint8Array;
 
 type EncodeFn = (value: U8aLike, ipfsCompat?: boolean) => string;
 
-type ValidateFn = (value?: unknown, ipfsCompat?: boolean, allowEmpty?: boolean) => value is string;
+type ValidateFn = (value?: unknown, ipfsCompat?: boolean) => value is string;
 
 /** @internal */
 export function createDecode ({ coder, ipfs }: Config, validate: ValidateFn): DecodeFn {
   return (value: string, ipfsCompat?: boolean): Uint8Array => {
-    validate(value, ipfsCompat, true);
+    validate(value, ipfsCompat);
 
     return coder.decode(
       ipfs && ipfsCompat
@@ -64,8 +64,8 @@ export function createIs (validate: ValidateFn): ValidateFn {
 
 /** @internal */
 export function createValidate ({ chars, ipfs, type }: Config): ValidateFn {
-  return (value?: unknown, ipfsCompat?: boolean, allowEmpty?: boolean): value is string => {
-    if (typeof value !== 'string' || (!value && !allowEmpty)) {
+  return (value?: unknown, ipfsCompat?: boolean): value is string => {
+    if (typeof value !== 'string') {
       throw new Error(`Expected ${type} string input`);
     } else if (ipfs && ipfsCompat && value[0] !== ipfs) {
       throw new Error(`Expected ipfs-compatible ${type} to start with '${ipfs}'`);

--- a/packages/util-crypto/src/base32/validate.spec.ts
+++ b/packages/util-crypto/src/base32/validate.spec.ts
@@ -18,6 +18,18 @@ describe('base32Validate', (): void => {
     ).toEqual(true);
   });
 
+  it('fails on empty', (): void => {
+    expect(
+      () => base32Validate('')
+    ).toThrow(/Expected/);
+  });
+
+  it('does not fail on empty (with allowEmpty)', (): void => {
+    expect(
+      () => base32Validate('', undefined, true)
+    ).not.toThrow();
+  });
+
   it('fails on non-string', (): void => {
     expect(
       () => base32Validate(true)

--- a/packages/util-crypto/src/base32/validate.spec.ts
+++ b/packages/util-crypto/src/base32/validate.spec.ts
@@ -18,16 +18,10 @@ describe('base32Validate', (): void => {
     ).toEqual(true);
   });
 
-  it('fails on empty', (): void => {
+  it('does not fail on empty', (): void => {
     expect(
-      () => base32Validate('')
-    ).toThrow(/Expected/);
-  });
-
-  it('does not fail on empty (with allowEmpty)', (): void => {
-    expect(
-      () => base32Validate('', undefined, true)
-    ).not.toThrow();
+      base32Validate('')
+    ).toEqual(true);
   });
 
   it('fails on non-string', (): void => {

--- a/packages/util-crypto/src/base32/validate.spec.ts
+++ b/packages/util-crypto/src/base32/validate.spec.ts
@@ -18,12 +18,6 @@ describe('base32Validate', (): void => {
     ).toEqual(true);
   });
 
-  it('fails on empty', (): void => {
-    expect(
-      () => base32Validate('')
-    ).toThrow(/Expected/);
-  });
-
   it('fails on non-string', (): void => {
     expect(
       () => base32Validate(true)

--- a/packages/util-crypto/src/base58/decode.spec.ts
+++ b/packages/util-crypto/src/base58/decode.spec.ts
@@ -7,6 +7,12 @@ import { base32Decode } from '../base32/index.js';
 import { base58Decode } from './index.js';
 
 describe('base58Encode', (): void => {
+  it('decodes an empty string)', (): void => {
+    expect(
+      base58Decode('')
+    ).toEqual(new Uint8Array());
+  });
+
   it('encodes a base58 to a base32', (): void => {
     expect(
       base58Decode('b2rhk6GMPQF3hfzwXTaNYFLKomMeC6UXdUt6jZKPpeVirLtV')

--- a/packages/util-crypto/src/base64/decode.spec.ts
+++ b/packages/util-crypto/src/base64/decode.spec.ts
@@ -8,6 +8,14 @@ import { stringToU8a } from '@polkadot/util';
 import { base64Decode } from './index.js';
 
 describe('base64Decode', (): void => {
+  it('decodes an empty string)', (): void => {
+    expect(
+      base64Decode('')
+    ).toEqual(
+      stringToU8a('')
+    );
+  });
+
   it('decodes a mixed base64 utf8 string (1)', (): void => {
     expect(
       base64Decode('aGVsbG8gd29ybGQg0J/RgNC40LLQtdGC0YHRgtCy0YPRjiDQvNC4IOS9oOWlvQ==')


### PR DESCRIPTION
Found as part of https://github.com/polkadot-js/common/pull/1785 (where those utils mismatches with our inputs)

Additionally the underlying base* decoders do accept and decode it correctly.