### PR TITLE
Fix decoding i8/i16 by using DataView and preventing future false use of `u8aToNumber` by deprecating it

### DIFF
--- a/packages/util/src/u8a/index.ts
+++ b/packages/util/src/u8a/index.ts
@@ -16,7 +16,7 @@ export { u8aToBn } from './toBn.js';
 export { u8aToBuffer } from './toBuffer.js';
 export { u8aToFloat } from './toFloat.js';
 export { u8aToHex } from './toHex.js';
-export { u8aToNumber } from './toNumber.js';
+export { u8aToNumber, u8aToUnsignedNumber, u8aToSignedNumber } from './toNumber.js';
 export { u8aToString } from './toString.js';
 export { u8aToU8a } from './toU8a.js';
 export { U8A_WRAP_ETHEREUM, U8A_WRAP_POSTFIX, U8A_WRAP_PREFIX, u8aIsWrapped, u8aUnwrapBytes, u8aWrapBytes } from './wrap.js';

--- a/packages/util/src/u8a/toNumber.spec.ts
+++ b/packages/util/src/u8a/toNumber.spec.ts
@@ -3,135 +3,458 @@
 
 /// <reference types="@polkadot/dev-test/globals.d.ts" />
 
-import { perf } from '../test/index.js';
-import { u8aToNumber } from './index.js';
+import { u8aToUnsignedNumber, u8aToSignedNumber } from './index.js';
 
-describe('u8aToNumber', (): void => {
-  describe('unsigned', (): void => {
-    it('converts values (u8)', (): void => {
+describe('u8aToSignedNumber', (): void => {
+  describe('i8', (): void => {
+    it('converts values (-128i8)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([0x12])
+        u8aToSignedNumber(
+          new Uint8Array([128])
         )
-      ).toBe(18);
+      ).toBe(-128);
     });
 
-    it('converts values (u16)', (): void => {
+    it('converts values (-127i8)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([0x12, 0x34])
+        u8aToSignedNumber(
+          new Uint8Array([129])
         )
-      ).toBe(13330);
+      ).toBe(-127);
     });
 
-    it('converts values (u24)', (): void => {
+    it('converts values (-123i8)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([0x12, 0x34, 0x56])
+        u8aToSignedNumber(
+          new Uint8Array([133])
         )
-      ).toBe(5649426);
+      ).toBe(-123);
     });
 
-    it('converts values (u32)', (): void => {
+    it('converts values (-42i8)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([0x12, 0x34, 0x56, 0x78])
+        u8aToSignedNumber(
+          new Uint8Array([214])
         )
-      ).toBe(2018915346);
+      ).toBe(-42);
     });
 
-    it('converts values (u40)', (): void => {
+    it('converts values (-1i8)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x9a])
+        u8aToSignedNumber(
+          new Uint8Array([255])
         )
-      ).toBe(663443878930);
+      ).toBe(-1);
     });
 
-    it('converts values (u48)', (): void => {
+    it('converts values (0i8)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc])
+        u8aToSignedNumber(
+          new Uint8Array([0])
         )
-      ).toBe(207371629900818);
+      ).toBe(0);
     });
+
+    it('converts values (0i8)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([0])
+        )
+      ).toBe(0);
+    });
+
+    it('converts values (1i8)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([1])
+        )
+      ).toBe(1);
+    });
+
+    it('converts values (42i8)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([42])
+        )
+      ).toBe(42);
+    });
+
+    it('converts values (123i8)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([123])
+        )
+      ).toBe(123);
+    });
+
+    it('converts values (126i8)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([126])
+        )
+      ).toBe(126);
+    });
+
+    it('converts values (127i8)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([127])
+        )
+      ).toBe(127);
+    });
+
+
   });
 
-  describe('signed', (): void => {
-    it('converts values (i8)', (): void => {
+  describe('i16', (): void => {
+    it('converts values (-32768i16)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([244]),
-          { isNegative: true }
+        u8aToSignedNumber(
+          new Uint8Array([0, 128])
         )
-      ).toBe(-12);
+      ).toBe(-32768);
     });
 
-    it('converts values (i16)', (): void => {
+    it('converts values (-32767i16)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([46, 251]),
-          { isNegative: true }
+        u8aToSignedNumber(
+          new Uint8Array([1, 128])
+        )
+      ).toBe(-32767);
+    });
+
+    it('converts values (-12345i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([199, 207])
+        )
+      ).toBe(-12345);
+    });
+
+    it('converts values (-42i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([214, 255])
+        )
+      ).toBe(-42);
+    });
+
+    it('converts values (-1i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([255, 255])
+        )
+      ).toBe(-1);
+    });
+
+    it('converts values (0i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([0, 0])
+        )
+      ).toBe(0);
+    });
+
+    it('converts values (0i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([0, 0])
+        )
+      ).toBe(0);
+    });
+
+    it('converts values (1i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([1, 0])
+        )
+      ).toBe(1);
+    });
+
+    it('converts values (42i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([42, 0])
+        )
+      ).toBe(42);
+    });
+
+    it('converts values (12345i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([57, 48])
+        )
+      ).toBe(12345);
+    });
+
+    it('converts values (32766i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([254, 127])
+        )
+      ).toBe(32766);
+    });
+
+    it('converts values (32767i16)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([255, 127])
+        )
+      ).toBe(32767);
+    });
+
+
+  });
+
+  describe('i32', (): void => {
+    it('converts values (-2147483648i32)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([0, 0, 0, 128])
+        )
+      ).toBe(-2147483648);
+    });
+
+    it('converts values (-2147483647i32)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([1, 0, 0, 128])
+        )
+      ).toBe(-2147483647);
+    });
+
+    it('converts values (-1234i32)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([46, 251, 255, 255])
         )
       ).toBe(-1234);
     });
 
-    it('converts values (i24)', (): void => {
+    it('converts values (-42i32)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([192, 29, 254]),
-          { isNegative: true }
+        u8aToSignedNumber(
+          new Uint8Array([214, 255, 255, 255])
         )
-      ).toBe(-123456);
+      ).toBe(-42);
     });
 
-    it('converts values (i32)', (): void => {
+    it('converts values (-1i32)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([235, 50, 164, 248]),
-          { isNegative: true }
+        u8aToSignedNumber(
+          new Uint8Array([255, 255, 255, 255])
         )
-      ).toBe(-123456789);
+      ).toBe(-1);
     });
 
-    it('converts values (i40)', (): void => {
+    it('converts values (0i32)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array([65, 86, 129, 173, 254]),
-          { isNegative: true }
-        )
-      ).toBe(-5678999999);
-    });
-
-    it('converts values (i48)', (): void => {
-      expect(
-        u8aToNumber(
-          new Uint8Array([1, 96, 141, 177, 231, 246]),
-          { isNegative: true }
-        )
-      ).toBe(-9999999999999);
-    });
-  });
-
-  describe('empty creation', (): void => {
-    it('handles unsigned (le)', (): void => {
-      expect(
-        u8aToNumber(
-          new Uint8Array()
+        u8aToSignedNumber(
+          new Uint8Array([0, 0, 0, 0])
         )
       ).toBe(0);
     });
 
-    it('handles signed (le)', (): void => {
+    it('converts values (0i32)', (): void => {
       expect(
-        u8aToNumber(
-          new Uint8Array(),
-          { isNegative: true }
+        u8aToSignedNumber(
+          new Uint8Array([0, 0, 0, 0])
         )
       ).toBe(0);
     });
+
+    it('converts values (1i32)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([1, 0, 0, 0])
+        )
+      ).toBe(1);
+    });
+
+    it('converts values (42i32)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([42, 0, 0, 0])
+        )
+      ).toBe(42);
+    });
+
+    it('converts values (1234i32)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([210, 4, 0, 0])
+        )
+      ).toBe(1234);
+    });
+
+    it('converts values (2147483646i32)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([254, 255, 255, 127])
+        )
+      ).toBe(2147483646);
+    });
+
+    it('converts values (2147483647i32)', (): void => {
+      expect(
+        u8aToSignedNumber(
+          new Uint8Array([255, 255, 255, 127])
+        )
+      ).toBe(2147483647);
+    });
   });
 
-  perf('u8aToNumber (i32)', 750_000, [[new Uint8Array([0x68, 0x65, 0x6c, 0x6c])]], (v: Uint8Array) => u8aToNumber(v, { isNegative: true }));
-  perf('u8aToNumber (u32)', 750_000, [[new Uint8Array([0x68, 0x65, 0x6c, 0x6c])]], u8aToNumber);
+});
+
+
+describe('u8aToUnsignedNumber', (): void => {
+  describe('u8', (): void => {
+    it('converts values (0u8)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([0])
+        )
+      ).toBe(0);
+    });
+
+    it('converts values (1u8)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([1])
+        )
+      ).toBe(1);
+    });
+
+    it('converts values (42u8)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([42])
+        )
+      ).toBe(42);
+    });
+
+    it('converts values (123u8)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([123])
+        )
+      ).toBe(123);
+    });
+
+    it('converts values (254u8)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([254])
+        )
+      ).toBe(254);
+    });
+
+    it('converts values (255u8)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([255])
+        )
+      ).toBe(255);
+    });
+  });
+
+  describe('u16', (): void => {
+    it('converts values (0u16)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([0, 0])
+        )
+      ).toBe(0);
+    });
+
+    it('converts values (1u16)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([1, 0])
+        )
+      ).toBe(1);
+    });
+
+    it('converts values (42u16)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([42, 0])
+        )
+      ).toBe(42);
+    });
+
+    it('converts values (12345u16)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([57, 48])
+        )
+      ).toBe(12345);
+    });
+
+    it('converts values (65534u16)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([254, 255])
+        )
+      ).toBe(65534);
+    });
+
+    it('converts values (65535u16)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([255, 255])
+        )
+      ).toBe(65535);
+    });
+  });
+
+  describe('u32', (): void => {
+    it('converts values (0u32)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([0, 0, 0, 0])
+        )
+      ).toBe(0);
+    });
+
+    it('converts values (1u32)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([1, 0, 0, 0])
+        )
+      ).toBe(1);
+    });
+
+    it('converts values (42u32)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([42, 0, 0, 0])
+        )
+      ).toBe(42);
+    });
+
+    it('converts values (1234567u32)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([135, 214, 18, 0])
+        )
+      ).toBe(1234567);
+    });
+
+    it('converts values (4294967294u32)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([254, 255, 255, 255])
+        )
+      ).toBe(4294967294);
+    });
+
+    it('converts values (4294967295u32)', (): void => {
+      expect(
+        u8aToUnsignedNumber(
+          new Uint8Array([255, 255, 255, 255])
+        )
+      ).toBe(4294967295);
+    });
+  });
 });

--- a/packages/util/src/u8a/toNumber.ts
+++ b/packages/util/src/u8a/toNumber.ts
@@ -3,16 +3,18 @@
 
 interface ToNumberOptions {
   /**
+   * @deprecated Use `u8aToUnsignedNumber` or `u8aToSignedNumber` instead.
    * @description Number is signed, apply two's complement
    */
   isNegative?: boolean;
 }
 
 /**
+ * @deprecated Use `u8aToUnsignedNumber` or `u8aToSignedNumber` instead.
  * @name u8aToNumber
  * @summary Creates a number from a Uint8Array object. This only operates on LE values as used in SCALE.
  */
-export function u8aToNumber (value: Uint8Array, { isNegative = false }: ToNumberOptions = {}): number {
+export function u8aToNumber(value: Uint8Array, { isNegative = false }: ToNumberOptions = {}): number {
   const count = value.length;
 
   if (isNegative) {
@@ -69,6 +71,54 @@ export function u8aToNumber (value: Uint8Array, { isNegative = false }: ToNumber
     case 6:
       return value[0] + (value[1] << 8) + (value[2] << 16) + ((value[3] + (value[4] << 8) + (value[5] << 16)) * 0x1_00_00_00);
 
+    default:
+      throw new Error('Value more than 48-bits cannot be reliably converted');
+  }
+}
+
+/**
+ * @name u8aToUnsignedNumber
+ * @summary Creates a unsigned number from a Uint8Array object. This only operates on LE values as used in SCALE.
+ */
+export function u8aToUnsignedNumber(value: Uint8Array): number {
+  const count = value.length;
+
+  if (count === 0) {
+    return 0; // TODO throw error  no bytes available
+  }
+
+  switch (count * 8) {
+    case 8:
+      return new DataView(value.buffer).getUint8(0);
+    case 16:
+      return new DataView(value.buffer).getUint16(0, true);
+    case 32:
+      return new DataView(value.buffer).getUint32(0, true);
+    default:
+      throw new Error('Value more than 48-bits cannot be reliably converted');
+  }
+}
+
+/**
+ * @name u8aToSignedNumber
+ * @summary Creates a signed number from a Uint8Array object. This only operates on LE values as used in SCALE.
+ */
+export function u8aToSignedNumber(value: Uint8Array): number {
+  const count = value.length;
+
+  if (count === 0) {
+    return 0; // TODO throw error  no bytes available
+  }
+
+  switch (count * 8) {
+    case 8:
+      return new DataView(value.buffer).getInt8(0);
+
+    case 16:
+      return new DataView(value.buffer).getInt16(0, true);
+
+    case 32:
+      return new DataView(value.buffer).getInt32(0, true);
     default:
       throw new Error('Value more than 48-bits cannot be reliably converted');
   }

--- a/packages/util/src/u8a/toNumberDeprecated.spec.ts
+++ b/packages/util/src/u8a/toNumberDeprecated.spec.ts
@@ -142,6 +142,7 @@ describe('u8aToNumber', (): void => {
       ).toBe(0);
     });
 
+    // Fails, as "isNegative" is set to try, see below why
     it('converts values (127i8)', (): void => {
       expect(
         u8aToNumber(
@@ -149,6 +150,16 @@ describe('u8aToNumber', (): void => {
           { isNegative: true } // always set to true by `Int` https://github.com/polkadot-js/api/blob/master/packages/types-codec/src/abstract/Int.ts#L95-L100
         )
       ).toBe(127);
+    });
+
+    // Succeeds again for i32, but why? What to adapt for i8 & i16?
+    it('converts values (42i32)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([42, 0, 0, 0]),
+          { isNegative: true } // always set to true by `Int` https://github.com/polkadot-js/api/blob/master/packages/types-codec/src/abstract/Int.ts#L95-L100
+        )
+      ).toBe(42);
     });
   });
 

--- a/packages/util/src/u8a/toNumberDeprecated.spec.ts
+++ b/packages/util/src/u8a/toNumberDeprecated.spec.ts
@@ -1,0 +1,137 @@
+// Copyright 2017-2023 @polkadot/util authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// <reference types="@polkadot/dev-test/globals.d.ts" />
+
+import { perf } from '../test/index.js';
+import { u8aToNumber } from './index.js';
+
+describe('u8aToNumber', (): void => {
+  describe('unsigned', (): void => {
+    it('converts values (u8)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0x12])
+        )
+      ).toBe(18);
+    });
+
+    it('converts values (u16)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0x12, 0x34])
+        )
+      ).toBe(13330);
+    });
+
+    it('converts values (u24)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0x12, 0x34, 0x56])
+        )
+      ).toBe(5649426);
+    });
+
+    it('converts values (u32)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0x12, 0x34, 0x56, 0x78])
+        )
+      ).toBe(2018915346);
+    });
+
+    it('converts values (u40)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x9a])
+        )
+      ).toBe(663443878930);
+    });
+
+    it('converts values (u48)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc])
+        )
+      ).toBe(207371629900818);
+    });
+  });
+
+  describe('signed', (): void => {
+    it('converts values (i8)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([244]),
+          { isNegative: true }
+        )
+      ).toBe(-12);
+    });
+
+    it('converts values (i16)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([46, 251]),
+          { isNegative: true }
+        )
+      ).toBe(-1234);
+    });
+
+    it('converts values (i24)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([192, 29, 254]),
+          { isNegative: true }
+        )
+      ).toBe(-123456);
+    });
+
+    it('converts values (i32)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([235, 50, 164, 248]),
+          { isNegative: true }
+        )
+      ).toBe(-123456789);
+    });
+
+    it('converts values (i40)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([65, 86, 129, 173, 254]),
+          { isNegative: true }
+        )
+      ).toBe(-5678999999);
+    });
+
+    it('converts values (i48)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([1, 96, 141, 177, 231, 246]),
+          { isNegative: true }
+        )
+      ).toBe(-9999999999999);
+    });
+  });
+
+  describe('empty creation', (): void => {
+    it('handles unsigned (le)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array()
+        )
+      ).toBe(0);
+    });
+
+    it('handles signed (le)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array(),
+          { isNegative: true }
+        )
+      ).toBe(0);
+    });
+  });
+
+  perf('u8aToNumber (i32)', 750_000, [[new Uint8Array([0x68, 0x65, 0x6c, 0x6c])]], (v: Uint8Array) => u8aToNumber(v, { isNegative: true }));
+  perf('u8aToNumber (u32)', 750_000, [[new Uint8Array([0x68, 0x65, 0x6c, 0x6c])]], u8aToNumber);
+});

--- a/packages/util/src/u8a/toNumberDeprecated.spec.ts
+++ b/packages/util/src/u8a/toNumberDeprecated.spec.ts
@@ -111,6 +111,45 @@ describe('u8aToNumber', (): void => {
         )
       ).toBe(-9999999999999);
     });
+
+    // Fails
+    it('converts values (0i8)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0]),
+          { isNegative: true }
+        )
+      ).toBe(0);
+    });
+
+    // Fails
+    it('converts values (0i16)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0, 0]),
+          { isNegative: true }
+        )
+      ).toBe(0);
+    });
+
+    // Succeeds, why does it not work for i8 & i16? They need `isNegative=false` to work
+    it('converts values (0i32)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([0, 0, 0, 0]),
+          { isNegative: true }
+        )
+      ).toBe(0);
+    });
+
+    it('converts values (127i8)', (): void => {
+      expect(
+        u8aToNumber(
+          new Uint8Array([127]),
+          { isNegative: true } // always set to true by `Int` https://github.com/polkadot-js/api/blob/master/packages/types-codec/src/abstract/Int.ts#L95-L100
+        )
+      ).toBe(127);
+    });
   });
 
   describe('empty creation', (): void => {


### PR DESCRIPTION
change decoding of byte to number methods for numbers <=32 bits, furthermore limiting to use i8/16/32

using DataView api do implement simpler decoding of these fixed width numbers. Thereby deprecating `u8aToNumber()`. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView


Needed for https://github.com/polkadot-js/api/issues/5702 and https://github.com/polkadot-js/api/pull/5703


See https://github.com/polkadot-js/api/pull/5703#issuecomment-1684059771 for what was wrong with the previous implementation.
