### PR TITLE
feat: `isRiscV` guard function 

### DIFF
--- a/packages/util/src/is/index.ts
+++ b/packages/util/src/is/index.ts
@@ -25,6 +25,7 @@ export { isNumber } from './number.js';
 export { isObject } from './object.js';
 export { isObservable } from './observable.js';
 export { isPromise } from './promise.js';
+export { isRiscV } from './riscv.js';
 export { isString } from './string.js';
 export { isTestChain } from './testChain.js';
 export { isToBigInt } from './toBigInt.js';

--- a/packages/util/src/is/riscv.spec.ts
+++ b/packages/util/src/is/riscv.spec.ts
@@ -1,0 +1,30 @@
+// Copyright 2017-2023 @polkadot/util authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// <reference types="@polkadot/dev-test/globals.d.ts" />
+
+import { isRiscV } from './index.js';
+
+describe('isRiscV', (): void => {
+  it('is false on non-risc-v header', (): void => {
+    expect(isRiscV(new Uint8Array([0, 97, 115, 109, 1, 2, 3]))).toEqual(false);
+  });
+
+  it('is false on partial-risc-v header', (): void => {
+    expect(isRiscV(new Uint8Array([0x7f, 0x45, 0x4c]))).toEqual(false);
+  });
+
+  it('is false on empty byte before risc-v header', (): void => {
+    expect(
+      isRiscV(
+        new Uint8Array([0x00, 0x7f, 0x45, 0x4c, 0x46, 0xff, 0x00, 0x42, 0x23])
+      )
+    ).toEqual(false);
+  });
+
+  it('is true when a risc-v header is found', (): void => {
+    expect(
+      isRiscV(new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0xff, 0x00, 0x42, 0x23]))
+    ).toEqual(true);
+  });
+});

--- a/packages/util/src/is/riscv.ts
+++ b/packages/util/src/is/riscv.ts
@@ -1,0 +1,17 @@
+// Copyright 2017-2023 @polkadot/util authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { u8aEq } from '../u8a/eq.js';
+import { isU8a } from './u8a.js';
+
+const ELF_MAGIC = new Uint8Array([0x7f, 0x45, 0x4c, 0x46]); // ELF magic bytes: 0x7f, 'E', 'L', 'F'
+
+/**
+ * @name isRiscV
+ * @summary Tests if the input has a RISC-V header
+ * @description
+ * Checks to see if the input Uint8Array contains a valid RISC-V header
+ */
+export function isRiscV (bytes: unknown): bytes is Uint8Array {
+  return isU8a(bytes) && u8aEq(bytes.subarray(0, 4), ELF_MAGIC);
+}


### PR DESCRIPTION
Introduced in originally in this PR https://github.com/polkadot-js/api/pull/5699#pullrequestreview-1604611089 , it was suggested to be moved to the `@polkadot/common` package. 

I've basically just copied over the code form the pr in the api package. The `isWasm` and `isRiscV` function signature differs as the `isWasm`'s parameter of bytes is optional. Should we align both functions to have a optional or required parameter? 

https://github.com/peetzweg/common/blob/d8a4d018f18fe69f2ad796d986ff950335cb2b35/packages/util/src/is/riscv.ts#L15-L17

https://github.com/peetzweg/common/blob/d8a4d018f18fe69f2ad796d986ff950335cb2b35/packages/util/src/is/wasm.ts#L15-L17