### PR TITLE
Get rid of warnings for dual esm and cjs packages of the same version

### DIFF
--- a/packages/util/src/versionDetect.spec.ts
+++ b/packages/util/src/versionDetect.spec.ts
@@ -70,3 +70,19 @@ The following conflicting packages were found:
     spy.mockRestore();
   });
 });
+
+describe('detectPackageEsmCjs', (): void => {
+  const PKG = '@polkadot/wasm-crypto';
+  const VER1 = '9.8.0-beta.45';
+  const PATH = '/Users/jaco/Projects/polkadot-js/api/node_modules/@polkadot/api/node_modules/@polkadot/wasm-crypto'
+  it('should not log when there are concurrent esm and cjs versions of the same package with the same version number', (): void => {
+    const spy = jest.spyOn(console, 'warn');
+    const pkgEsm = { name: PKG, path: PATH, type: 'esm', version: VER1 }
+    const pkgCjs = { name: PKG, path: `${PATH}/cjs`, type: 'cjs', version: VER1 }
+    detectPackage(pkgEsm, false, []);
+    detectPackage(pkgCjs,  false, [] );
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+})

--- a/packages/util/src/versionDetect.spec.ts
+++ b/packages/util/src/versionDetect.spec.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="@polkadot/dev-test/globals.d.ts" />
 
-import { detectPackage } from './versionDetect.js';
+import { detectPackage, POLKADOTJS_DISABLE_ESM_CJS_WARNING_FLAG } from './versionDetect.js';
 
 describe('detectPackage', (): void => {
   const PKG = '@polkadot/util';
@@ -71,18 +71,40 @@ The following conflicting packages were found:
   });
 });
 
-describe('detectPackageEsmCjs', (): void => {
+describe('detectPackageEsmCjsNoWarnings', (): void => {
   const PKG = '@polkadot/wasm-crypto';
   const VER1 = '9.8.0-beta.45';
-  const PATH = '/Users/jaco/Projects/polkadot-js/api/node_modules/@polkadot/api/node_modules/@polkadot/wasm-crypto'
-  it('should not log when there are concurrent esm and cjs versions of the same package with the same version number', (): void => {
+  const PATH = '/Users/jaco/Projects/polkadot-js/api/node_modules/@polkadot/api/node_modules/@polkadot/wasm-crypto';
+
+  it('should not log when there are concurrent esm and cjs versions of the same package with the same version number and warnings are disabled', (): void => {
     const spy = jest.spyOn(console, 'warn');
-    const pkgEsm = { name: PKG, path: PATH, type: 'esm', version: VER1 }
-    const pkgCjs = { name: PKG, path: `${PATH}/cjs`, type: 'cjs', version: VER1 }
+    const pkgEsm = { name: PKG, path: PATH, type: 'esm', version: VER1 };
+    const pkgCjs = { name: PKG, path: `${PATH}/cjs`, type: 'cjs', version: VER1 };
+
+    process.env[POLKADOTJS_DISABLE_ESM_CJS_WARNING_FLAG] = '1';
     detectPackage(pkgEsm, false, []);
-    detectPackage(pkgCjs,  false, [] );
+    detectPackage(pkgCjs, false, []);
 
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
-})
+});
+
+describe('detectPackageEsmCjs', (): void => {
+  const PKG = '@polkadot/wasm-crypto-wasm';
+  const VER1 = '9.8.0-beta.45';
+  const PATH = '/Users/jaco/Projects/polkadot-js/api/node_modules/@polkadot/api/node_modules/@polkadot/wasm-crypto-wasm';
+
+  it('should log when there are concurrent esm and cjs versions of the same package with the same version number and warnings are not disabled', (): void => {
+    const spy = jest.spyOn(console, 'warn');
+    const pkgEsm = { name: PKG, path: PATH, type: 'esm', version: VER1 };
+    const pkgCjs = { name: PKG, path: `${PATH}/cjs`, type: 'cjs', version: VER1 };
+
+    process.env[POLKADOTJS_DISABLE_ESM_CJS_WARNING_FLAG] = undefined;
+    detectPackage(pkgEsm, false, []);
+    detectPackage(pkgCjs, false, []);
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/util/src/versionDetect.ts
+++ b/packages/util/src/versionDetect.ts
@@ -105,7 +105,7 @@ function warn <T extends { version: string }> (pre: string, all: T[], fmt: (vers
 /**
  * @name detectPackage
  * @summary Checks that a specific package is only imported once
- * @description A `@polkadot/*` version detection utility, checking for one occurence of a package in addition to checking for ddependency versions.
+ * @description A `@polkadot/*` version detection utility, checking for one occurrence of a package in addition to checking for dependency versions.
  */
 export function detectPackage ({ name, path, type, version }: PackageInfo, pathOrFn?: FnString | string | false | null, deps: PackageInfo[] = []): void {
   if (!name.startsWith('@polkadot')) {
@@ -116,7 +116,9 @@ export function detectPackage ({ name, path, type, version }: PackageInfo, pathO
 
   entry.push({ path: getPath(path, pathOrFn), type, version });
 
-  if (entry.length !== 1) {
+  // if we have more than one entry at DIFFERENT version types then warn. If there is more than one entry at the same
+  // version, then it's just the esm and cjs versions installed alongside each other, which is fine.
+  if (entry.length !== 1 && !entry.every((e) => e.version === version)) {
     warn(`${name} has multiple versions, ensure that there is only one installed.`, entry, formatVersion);
   } else {
     const mismatches = deps.filter((d) => d && d.version !== version);


### PR DESCRIPTION
These warnings are really annoying for dual esm and cjs packages and take up most of the terminal making it hard to debug.

```
(Use `node --trace-warnings ...` to show where the warning was created)
(node:18971) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
@polkadot/util has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	esm 12.3.2	node_modules/@polkadot/util/
	cjs 12.3.2	node_modules/@polkadot/util/cjs
@polkadot/types has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	esm 10.9.1	node_modules/@polkadot/types/
	cjs 10.9.1	node_modules/@polkadot/types/cjs
@polkadot/types-create has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	esm 10.9.1	node_modules/@polkadot/types-create/
	cjs 10.9.1	node_modules/@polkadot/types-create/cjs
@polkadot/types-codec has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	esm 10.9.1	node_modules/@polkadot/types-codec/
	cjs 10.9.1	node_modules/@polkadot/types-codec/cjs
@polkadot/util-crypto has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	esm 12.3.2	node_modules/@polkadot/util-crypto/
	cjs 12.3.2	node_modules/@polkadot/util-crypto/cjs
	
+ many more lines...

```

This PR removes them when the versions are the same as there is no problem with having both esm and cjs versions installed with the same version number.