### PR TITLE
Adjust `isRiscV` helper to check for `PVM\0` bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Contributed:
 Changes:
 
 - Adjust logger check for `process.env`
+- Adjust `isRiscV` helper to check for `PVM\0` bytes
 - Drop support for Node 16 (EOL 11 Sep 2023)
 - Upgrade dependencies to latest stable versions
 

--- a/packages/util/src/is/riscv.spec.ts
+++ b/packages/util/src/is/riscv.spec.ts
@@ -6,15 +6,15 @@
 import { isRiscV } from './index.js';
 
 describe('isRiscV', (): void => {
-  it('is false on non-risc-v/non-pvm header', (): void => {
+  it('is false on non-elf/non-pvm header', (): void => {
     expect(isRiscV(new Uint8Array([0, 97, 115, 109, 1, 2, 3]))).toEqual(false);
   });
 
-  it('is false on partial-risc-v/pvm header', (): void => {
+  it('is false on partial-elf/pvm header', (): void => {
     expect(isRiscV(new Uint8Array([0x7f, 0x45, 0x4c]))).toEqual(false);
   });
 
-  it('is false on empty byte before risc-v/pvm header', (): void => {
+  it('is false on empty byte before elf/pvm header', (): void => {
     expect(
       isRiscV(
         new Uint8Array([0x00, 0x7f, 0x45, 0x4c, 0x46, 0xff, 0x00, 0x42, 0x23])
@@ -22,7 +22,7 @@ describe('isRiscV', (): void => {
     ).toEqual(false);
   });
 
-  it('is true when a risc-v header is found', (): void => {
+  it('is true when a elf header is found', (): void => {
     expect(
       isRiscV(new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0xff, 0x00, 0x42, 0x23]))
     ).toEqual(true);

--- a/packages/util/src/is/riscv.spec.ts
+++ b/packages/util/src/is/riscv.spec.ts
@@ -6,15 +6,15 @@
 import { isRiscV } from './index.js';
 
 describe('isRiscV', (): void => {
-  it('is false on non-risc-v header', (): void => {
+  it('is false on non-risc-v/non-pvm header', (): void => {
     expect(isRiscV(new Uint8Array([0, 97, 115, 109, 1, 2, 3]))).toEqual(false);
   });
 
-  it('is false on partial-risc-v header', (): void => {
+  it('is false on partial-risc-v/pvm header', (): void => {
     expect(isRiscV(new Uint8Array([0x7f, 0x45, 0x4c]))).toEqual(false);
   });
 
-  it('is false on empty byte before risc-v header', (): void => {
+  it('is false on empty byte before risc-v/pvm header', (): void => {
     expect(
       isRiscV(
         new Uint8Array([0x00, 0x7f, 0x45, 0x4c, 0x46, 0xff, 0x00, 0x42, 0x23])
@@ -25,6 +25,12 @@ describe('isRiscV', (): void => {
   it('is true when a risc-v header is found', (): void => {
     expect(
       isRiscV(new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0xff, 0x00, 0x42, 0x23]))
+    ).toEqual(true);
+  });
+
+  it('is true when a pvm header is found', (): void => {
+    expect(
+      isRiscV(new Uint8Array([0x50, 0x56, 0x4d, 0x00, 0xff, 0x00, 0x42, 0x23]))
     ).toEqual(true);
   });
 });

--- a/packages/util/src/is/riscv.ts
+++ b/packages/util/src/is/riscv.ts
@@ -4,7 +4,7 @@
 import { u8aEq } from '../u8a/eq.js';
 import { isU8a } from './u8a.js';
 
-const ELF_MAGIC = new Uint8Array([0x7f, 0x45, 0x4c, 0x46]); // ELF magic bytes: 0x7f, 'E', 'L', 'F'
+const ELF_MAGIC = new Uint8Array([0x50, 0x56, 0x4d, 0x00]); // 'P', 'V', 'M', 0x00
 
 /**
  * @name isRiscV

--- a/packages/util/src/is/riscv.ts
+++ b/packages/util/src/is/riscv.ts
@@ -4,7 +4,11 @@
 import { u8aEq } from '../u8a/eq.js';
 import { isU8a } from './u8a.js';
 
-const ELF_MAGIC = new Uint8Array([0x50, 0x56, 0x4d, 0x00]); // 'P', 'V', 'M', 0x00
+// general elf header
+const ELF_MAGIC = new Uint8Array([0x7f, 0x45, 0x4c, 0x46]); // ELF magic bytes: 0x7f, 'E', 'L', 'F'
+
+// contract-specific PVM header
+const PVM_MAGIC = new Uint8Array([0x50, 0x56, 0x4d, 0x00]); // 'P', 'V', 'M', 0x00
 
 /**
  * @name isRiscV
@@ -13,5 +17,11 @@ const ELF_MAGIC = new Uint8Array([0x50, 0x56, 0x4d, 0x00]); // 'P', 'V', 'M', 0x
  * Checks to see if the input Uint8Array contains a valid RISC-V header
  */
 export function isRiscV (bytes: unknown): bytes is Uint8Array {
-  return isU8a(bytes) && u8aEq(bytes.subarray(0, 4), ELF_MAGIC);
+  if (isU8a(bytes)) {
+    const start = bytes.subarray(0, 4);
+
+    return u8aEq(start, PVM_MAGIC) || u8aEq(start, ELF_MAGIC);
+  }
+
+  return false;
 }


### PR DESCRIPTION
Closes https://github.com/polkadot-js/common/issues/1893