### PR TITLE
Adds matrixchain to ss58 tests

### DIFF
--- a/packages/networks/test/ss58registry.json
+++ b/packages/networks/test/ss58registry.json
@@ -1263,16 +1263,16 @@
   },
   {
     "prefix": 1110,
-    "network": "efinity",
-    "displayName": "Efinity",
+    "network": "matrixchain",
+    "displayName": "Enjin Matrixchain",
     "symbols": [
-      "EFI"
+      "ENJ"
     ],
     "decimals": [
       18
     ],
     "standardAccount": "*25519",
-    "website": "https://efinity.io/"
+    "website": "https://enjin.io/"
   },
   {
     "prefix": 1221,
@@ -1472,7 +1472,7 @@
   {
     "prefix": 2135,
     "network": "enjin",
-    "displayName": "Enjin",
+    "displayName": "Enjin Relaychain",
     "symbols": [
       "ENJ"
     ],

--- a/packages/networks/test/ss58registry.json
+++ b/packages/networks/test/ss58registry.json
@@ -1470,6 +1470,19 @@
     "website": "https://chainflip.io/"
   },
   {
+    "prefix": 2135,
+    "network": "enjin",
+    "displayName": "Enjin",
+    "symbols": [
+      "ENJ"
+    ],
+    "decimals": [
+      18
+    ],
+    "standardAccount": "*25519",
+    "website": "https://enjin.io/"
+  },
+  {
     "prefix": 2199,
     "network": "moonsama",
     "displayName": "Moonsama",


### PR DESCRIPTION
Hello @TarikGul , where do I add the networks to appear when connecting a ledger to the polkadot-js extension?
We've added in the other network/genesis/etc files and still can't get to show in the dropdown.

![CleanShot 2024-06-25 at 18 10 34@2x](https://github.com/polkadot-js/common/assets/5619696/7cde7e3e-c40b-49e8-be01-ef311637dada)
