### PR TITLE
Remove slip44, and replace with POLKADOT_SLIP

### DIFF
--- a/packages/hw-ledger/src/constants.ts
+++ b/packages/hw-ledger/src/constants.ts
@@ -8,3 +8,5 @@ export const LEDGER_DEFAULT_CHANGE = 0x80000000;
 export const LEDGER_DEFAULT_INDEX = 0x80000000;
 
 export const LEDGER_SUCCESS_CODE = 0x9000;
+
+export const POLKADOT_SLIP = 0x00000162;


### PR DESCRIPTION
This removes the `slip44` arg from the constructor of `LedgerGeneric`.  It's not necessary and just flat out breaks the ledger interface for all chains but polkadot. This was an oversight by me, and needs to just be the polkadot slip44 for all chains.

That being said for this reason I am considering this a patch. 