### PR TITLE
Add bittensor to genericLedgerApps

### DIFF
--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -50,6 +50,7 @@ export const prevLedgerRecord: Record<string, string> = {
 
 // Any chains moving forward that are supported by the PolkadotGenericApp from ledger will input their names below.
 export const genericLedgerApps = {
+  bittensor: 'Bittensor',
   encointer: 'Encointer',
   integritee: 'Integritee'
 };

--- a/packages/networks/src/defaults/ledger.ts
+++ b/packages/networks/src/defaults/ledger.ts
@@ -14,6 +14,7 @@ export const knownLedger: KnownLedger = {
   astar: 0x0000032a,
   bifrost: 0x00000314,
   'bifrost-kusama': 0x00000314,
+  bittensor: 0x00000162,
   centrifuge: 0x000002eb,
   composable: 0x00000162,
   darwinia: 0x00000162,


### PR DESCRIPTION
Bittensor has applied the runtime upgrade for the generic Ledger app integration.
This PR adds it to the mapping of `genericLedgerApps`