### PR TITLE
Add Frequency to the Generic Ledger App

### DIFF
--- a/packages/hw-ledger/src/defaults.ts
+++ b/packages/hw-ledger/src/defaults.ts
@@ -52,6 +52,7 @@ export const prevLedgerRecord: Record<string, string> = {
 export const genericLedgerApps = {
   bittensor: 'Bittensor',
   encointer: 'Encointer',
+  frequency: 'Frequency',
   integritee: 'Integritee',
   polimec: 'Polimec'
 };

--- a/packages/networks/src/defaults/genesis.ts
+++ b/packages/networks/src/defaults/genesis.ts
@@ -65,6 +65,9 @@ export const knownGenesis: KnownGenesis = {
   equilibrium: [
     '0x6f1a800de3daff7f5e037ddf66ab22ce03ab91874debeddb1086f5f7dbd48925'
   ],
+  frequency: [
+    '0x4a587bf17a404e3572747add7aab7bbe56e805a5479c6c436f07f36fcc8d3ae1'
+  ],
   genshiro: [
     '0x9b8cefc0eb5c568b527998bdd76c184e2b76ae561be76e4667072230217ea243'
   ],

--- a/packages/networks/src/defaults/ledger.ts
+++ b/packages/networks/src/defaults/ledger.ts
@@ -23,6 +23,7 @@ export const knownLedger: KnownLedger = {
   encointer: 0x000001b2,
   enjin: 0x00000483,
   equilibrium: 0x05f5e0fd,
+  frequency: 0x0000082b,
   genshiro: 0x05f5e0fc,
   hydradx: 0x00000162,
   integritee: 0x000007df,


### PR DESCRIPTION
[Frequency](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2F0.rpc.frequency.xyz#/explorer) has the CheckMetadataHash extension on Mainnet and supports the generic Ledger application. This PR is to enable it in polkadot-js apps and extension.