### PR TITLE
sr25519: switch from wasm to micro-sr25519

### DIFF
--- a/packages/util-crypto/package.json
+++ b/packages/util-crypto/package.json
@@ -36,6 +36,7 @@
     "@polkadot/x-bigint": "13.3.2-0-x",
     "@polkadot/x-randomvalues": "13.3.2-0-x",
     "@scure/base": "^1.1.7",
+    "micro-sr25519": "^0.1.0",
     "tslib": "^2.8.0"
   },
   "peerDependencies": {

--- a/packages/util-crypto/src/sr25519/agreement.spec.ts
+++ b/packages/util-crypto/src/sr25519/agreement.spec.ts
@@ -6,7 +6,6 @@
 import type { Keypair } from '../types.js';
 
 import { u8aToHex } from '@polkadot/util';
-import { waitReady } from '@polkadot/wasm-crypto';
 
 import { sr25519Agreement, sr25519PairFromSeed } from './index.js';
 
@@ -14,9 +13,7 @@ describe('agreement', (): void => {
   let pairA: Keypair;
   let pairB: Keypair;
 
-  beforeEach(async (): Promise<void> => {
-    await waitReady();
-
+  beforeEach((): void => {
     pairA = sr25519PairFromSeed('0x98b3d305d5a5eace562387e47e59badd4d77e3f72cabfb10a60f8a197059f0a8');
     pairB = sr25519PairFromSeed('0x9732eea001851ff862d949a1699c9971f3a26edbede2ad7922cbbe9a0701f366');
   });

--- a/packages/util-crypto/src/sr25519/agreement.ts
+++ b/packages/util-crypto/src/sr25519/agreement.ts
@@ -1,8 +1,9 @@
 // Copyright 2017-2025 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { getSharedSecret } from 'micro-sr25519';
+
 import { u8aToU8a } from '@polkadot/util';
-import { sr25519Agree } from '@polkadot/wasm-crypto';
 
 /**
  * @name sr25519Agreement
@@ -18,5 +19,5 @@ export function sr25519Agreement (secretKey: string | Uint8Array, publicKey: str
     throw new Error(`Invalid secretKey, received ${secretKeyU8a.length} bytes, expected 64`);
   }
 
-  return sr25519Agree(publicKeyU8a, secretKeyU8a);
+  return getSharedSecret(secretKeyU8a, publicKeyU8a);
 }

--- a/packages/util-crypto/src/sr25519/derive.ts
+++ b/packages/util-crypto/src/sr25519/derive.ts
@@ -3,10 +3,9 @@
 
 import type { Keypair } from '../types.js';
 
-import { isU8a } from '@polkadot/util';
+import * as sr25519 from 'micro-sr25519';
 
-import { sr25519PairFromU8a } from './pair/fromU8a.js';
-import { sr25519KeypairToU8a } from './pair/toU8a.js';
+import { isU8a } from '@polkadot/util';
 
 export function createDeriveFn (derive: (pair: Uint8Array, cc: Uint8Array) => Uint8Array): (keypair: Keypair, chainCode: Uint8Array) => Keypair {
   return (keypair: Keypair, chainCode: Uint8Array): Keypair => {
@@ -14,8 +13,9 @@ export function createDeriveFn (derive: (pair: Uint8Array, cc: Uint8Array) => Ui
       throw new Error('Invalid chainCode passed to derive');
     }
 
-    return sr25519PairFromU8a(
-      derive(sr25519KeypairToU8a(keypair), chainCode)
-    );
+    const secretKey = derive(keypair.secretKey, chainCode);
+    const publicKey = sr25519.getPublicKey(secretKey);
+
+    return { publicKey, secretKey };
   };
 }

--- a/packages/util-crypto/src/sr25519/deriveHard.ts
+++ b/packages/util-crypto/src/sr25519/deriveHard.ts
@@ -1,8 +1,7 @@
 // Copyright 2017-2025 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { sr25519DeriveKeypairHard } from '@polkadot/wasm-crypto';
-
+import * as sr25519 from 'micro-sr25519';
 import { createDeriveFn } from './derive.js';
 
-export const sr25519DeriveHard = /*#__PURE__*/ createDeriveFn(sr25519DeriveKeypairHard);
+export const sr25519DeriveHard = /*#__PURE__*/ createDeriveFn(sr25519.HDKD.secretHard);

--- a/packages/util-crypto/src/sr25519/derivePublic.ts
+++ b/packages/util-crypto/src/sr25519/derivePublic.ts
@@ -1,8 +1,9 @@
 // Copyright 2017-2025 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import * as sr25519 from 'micro-sr25519';
+
 import { isU8a, u8aToU8a } from '@polkadot/util';
-import { sr25519DerivePublicSoft } from '@polkadot/wasm-crypto';
 
 export function sr25519DerivePublic (publicKey: string | Uint8Array, chainCode: Uint8Array): Uint8Array {
   const publicKeyU8a = u8aToU8a(publicKey);
@@ -13,5 +14,5 @@ export function sr25519DerivePublic (publicKey: string | Uint8Array, chainCode: 
     throw new Error(`Invalid publicKey, received ${publicKeyU8a.length} bytes, expected 32`);
   }
 
-  return sr25519DerivePublicSoft(publicKeyU8a, chainCode);
+  return sr25519.HDKD.publicSoft(publicKeyU8a, chainCode);
 }

--- a/packages/util-crypto/src/sr25519/deriveSoft.ts
+++ b/packages/util-crypto/src/sr25519/deriveSoft.ts
@@ -1,8 +1,8 @@
 // Copyright 2017-2025 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { sr25519DeriveKeypairSoft } from '@polkadot/wasm-crypto';
+import * as sr25519 from 'micro-sr25519';
 
 import { createDeriveFn } from './derive.js';
 
-export const sr25519DeriveSoft = /*#__PURE__*/ createDeriveFn(sr25519DeriveKeypairSoft);
+export const sr25519DeriveSoft = /*#__PURE__*/ createDeriveFn(sr25519.HDKD.secretSoft);

--- a/packages/util-crypto/src/sr25519/pair/fromSeed.spec.ts
+++ b/packages/util-crypto/src/sr25519/pair/fromSeed.spec.ts
@@ -4,7 +4,6 @@
 /// <reference types="@polkadot/dev-test/globals.d.ts" />
 
 import { stringToU8a, u8aToHex } from '@polkadot/util';
-import { waitReady } from '@polkadot/wasm-crypto';
 
 import { mnemonicToMiniSecret } from '../../mnemonic/index.js';
 import { sr25519PairFromSeed } from '../index.js';
@@ -16,10 +15,6 @@ describe('sr25519PairFromSeed', (): void => {
     publicKey: new Uint8Array([116, 28, 8, 160, 111, 65, 197, 150, 96, 143, 103, 116, 37, 155, 217, 4, 51, 4, 173, 250, 93, 62, 234, 98, 118, 11, 217, 190, 151, 99, 77, 99]),
     secretKey: new Uint8Array([240, 16, 102, 96, 195, 221, 162, 63, 22, 218, 169, 172, 91, 129, 27, 150, 48, 119, 245, 188, 10, 248, 159, 133, 128, 79, 13, 232, 228, 36, 240, 80, 249, 141, 102, 243, 148, 66, 80, 111, 249, 71, 253, 145, 31, 24, 199, 167, 165, 218, 99, 154, 99, 232, 211, 180, 226, 51, 247, 65, 67, 217, 81, 193])
   };
-
-  beforeEach(async (): Promise<void> => {
-    await waitReady();
-  });
 
   it('generates a valid publicKey/secretKey pair (u8a)', (): void => {
     expect(

--- a/packages/util-crypto/src/sr25519/pair/fromSeed.ts
+++ b/packages/util-crypto/src/sr25519/pair/fromSeed.ts
@@ -3,10 +3,9 @@
 
 import type { Keypair } from '../../types.js';
 
-import { u8aToU8a } from '@polkadot/util';
-import { sr25519KeypairFromSeed } from '@polkadot/wasm-crypto';
+import * as sr25519 from 'micro-sr25519';
 
-import { sr25519PairFromU8a } from './fromU8a.js';
+import { u8aToU8a } from '@polkadot/util';
 
 /**
  * @name sr25519PairFromSeed
@@ -19,7 +18,11 @@ export function sr25519PairFromSeed (seed: string | Uint8Array): Keypair {
     throw new Error(`Expected a seed matching 32 bytes, found ${seedU8a.length}`);
   }
 
-  return sr25519PairFromU8a(
-    sr25519KeypairFromSeed(seedU8a)
-  );
+  const sec = sr25519.secretFromSeed(seedU8a);
+  const pub = sr25519.getPublicKey(sec);
+
+  return {
+    publicKey: pub,
+    secretKey: sec
+  };
 }

--- a/packages/util-crypto/src/sr25519/sign.spec.ts
+++ b/packages/util-crypto/src/sr25519/sign.spec.ts
@@ -4,7 +4,6 @@
 /// <reference types="@polkadot/dev-test/globals.d.ts" />
 
 import { stringToU8a } from '@polkadot/util';
-import { waitReady } from '@polkadot/wasm-crypto';
 
 import { randomAsU8a } from '../random/asU8a.js';
 import { sr25519PairFromSeed } from './pair/fromSeed.js';
@@ -13,10 +12,6 @@ import { sr25519Sign } from './sign.js';
 const MESSAGE = stringToU8a('this is a message');
 
 describe('sign', (): void => {
-  beforeEach(async (): Promise<void> => {
-    await waitReady();
-  });
-
   it('has 64-byte signatures', (): void => {
     const pair = sr25519PairFromSeed(randomAsU8a());
 

--- a/packages/util-crypto/src/sr25519/sign.ts
+++ b/packages/util-crypto/src/sr25519/sign.ts
@@ -3,8 +3,9 @@
 
 import type { Keypair } from '../types.js';
 
+import * as sr25519 from 'micro-sr25519';
+
 import { u8aToU8a } from '@polkadot/util';
-import { sr25519Sign as wasmSign } from '@polkadot/wasm-crypto';
 
 /**
  * @name sr25519Sign
@@ -17,5 +18,5 @@ export function sr25519Sign (message: string | Uint8Array, { publicKey, secretKe
     throw new Error('Expected a valid secretKey, 64-bytes');
   }
 
-  return wasmSign(publicKey, secretKey, u8aToU8a(message));
+  return sr25519.sign(secretKey, u8aToU8a(message));
 }

--- a/packages/util-crypto/src/sr25519/verify.spec.ts
+++ b/packages/util-crypto/src/sr25519/verify.spec.ts
@@ -4,7 +4,6 @@
 /// <reference types="@polkadot/dev-test/globals.d.ts" />
 
 import { stringToU8a } from '@polkadot/util';
-import { waitReady } from '@polkadot/wasm-crypto';
 
 import { randomAsU8a } from '../random/asU8a.js';
 import { sr25519PairFromSeed } from './pair/fromSeed.js';
@@ -14,10 +13,6 @@ import { sr25519Verify } from './verify.js';
 const MESSAGE = stringToU8a('this is a message');
 
 describe('verify', (): void => {
-  beforeEach(async (): Promise<void> => {
-    await waitReady();
-  });
-
   it('can sign and verify a message', (): void => {
     const pair = sr25519PairFromSeed(randomAsU8a());
     const signature = sr25519Sign(MESSAGE, pair);

--- a/packages/util-crypto/src/sr25519/verify.ts
+++ b/packages/util-crypto/src/sr25519/verify.ts
@@ -1,8 +1,9 @@
 // Copyright 2017-2025 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import * as sr25519 from 'micro-sr25519';
+
 import { u8aToU8a } from '@polkadot/util';
-import { sr25519Verify as wasmVerify } from '@polkadot/wasm-crypto';
 
 /**
  * @name sr25519Verify
@@ -18,5 +19,5 @@ export function sr25519Verify (message: string | Uint8Array, signature: string |
     throw new Error(`Invalid signature, received ${signatureU8a.length} bytes, expected 64`);
   }
 
-  return wasmVerify(signatureU8a, u8aToU8a(message), publicKeyU8a);
+  return sr25519.verify(u8aToU8a(message), signatureU8a, publicKeyU8a);
 }

--- a/packages/util-crypto/src/sr25519/vrfSign.ts
+++ b/packages/util-crypto/src/sr25519/vrfSign.ts
@@ -3,8 +3,9 @@
 
 import type { Keypair } from '../types.js';
 
+import * as sr25519 from 'micro-sr25519';
+
 import { u8aToU8a } from '@polkadot/util';
-import { vrfSign } from '@polkadot/wasm-crypto';
 
 const EMPTY_U8A = new Uint8Array();
 
@@ -17,5 +18,6 @@ export function sr25519VrfSign (message: string | Uint8Array, { secretKey }: Par
     throw new Error('Invalid secretKey, expected 64-bytes');
   }
 
-  return vrfSign(secretKey, u8aToU8a(context), u8aToU8a(message), u8aToU8a(extra));
+  return sr25519.vrf.sign(u8aToU8a(message), secretKey, u8aToU8a(context), u8aToU8a(extra));
+  // return vrfSign(secretKey, u8aToU8a(context), u8aToU8a(message), u8aToU8a(extra));
 }

--- a/packages/util-crypto/src/sr25519/vrfSignVerify.spec.ts
+++ b/packages/util-crypto/src/sr25519/vrfSignVerify.spec.ts
@@ -4,7 +4,6 @@
 /// <reference types="@polkadot/dev-test/globals.d.ts" />
 
 import { stringToU8a, u8aEq } from '@polkadot/util';
-import { waitReady } from '@polkadot/wasm-crypto';
 
 import { randomAsU8a } from '../random/asU8a.js';
 import { sr25519PairFromSeed } from './pair/fromSeed.js';
@@ -14,10 +13,6 @@ import { sr25519VrfVerify } from './vrfVerify.js';
 const MESSAGE = stringToU8a('this is a message');
 
 describe('vrf sign and verify', (): void => {
-  beforeEach(async (): Promise<void> => {
-    await waitReady();
-  });
-
   it('has 96-byte proofs', (): void => {
     const pair = sr25519PairFromSeed(randomAsU8a());
 

--- a/packages/util-crypto/src/sr25519/vrfVerify.ts
+++ b/packages/util-crypto/src/sr25519/vrfVerify.ts
@@ -1,8 +1,9 @@
 // Copyright 2017-2025 @polkadot/util-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import * as sr25519 from 'micro-sr25519';
+
 import { u8aToU8a } from '@polkadot/util';
-import { vrfVerify } from '@polkadot/wasm-crypto';
 
 const EMPTY_U8A = new Uint8Array();
 
@@ -20,5 +21,5 @@ export function sr25519VrfVerify (message: string | Uint8Array, signOutput: stri
     throw new Error('Invalid vrfSign output, expected 96 bytes');
   }
 
-  return vrfVerify(publicKeyU8a, u8aToU8a(context), u8aToU8a(message), u8aToU8a(extra), proofU8a);
+  return sr25519.vrf.verify(u8aToU8a(message), proofU8a, publicKeyU8a, u8aToU8a(context), u8aToU8a(extra));
 }


### PR DESCRIPTION
sr cryptography in 467 lines of js code: https://github.com/paulmillr/micro-sr25519

- All tests pass
- There are 2 linting issues which I have 0 ideas how to fix:

```
packages/util-crypto/src/sr25519/deriveHard.ts
  8:9  error  Avoid referencing unbound methods which may cause unintentional scoping of `this`.
If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead  @typescript-eslint/unbound-method

packages/util-crypto/src/sr25519/deriveSoft.ts
  8:63  error  Avoid referencing unbound methods which may cause unintentional scoping of `this`.
If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead  @typescript-eslint/unbound-method
```


As a side note, this repo's dev infrastructure is idiotic and urgently needs to be improved if the goal is to gain any new outside contributors. It took me 1 hour what should have taken 4 minutes. The test runner takes 3 minutes (too slow, not parallel) - would be great to have an option to crash on a first failed test. README and CONTRIBUTING.md have some bogus rules while not mentioning what's `polkadot-dev-run-test` and how it works. Linting is non-descriptive: for example, I don't understand what the rule above means (even though i've coded a few js libraries)