### PR TITLE
Fix: Use ws library in Node.js 22+ for Better WebSocket Error Handling

### DIFF
--- a/packages/x-ws/src/node.ts
+++ b/packages/x-ws/src/node.ts
@@ -14,6 +14,8 @@ export { packageInfo } from './packageInfo.js';
  *
  * To avoid these issues, we explicitly use the `ws` library in Node.js 22+
  * while still preserving support for the browser WebSocket API in browser environments.
+ *
+ * Related Issue: https://github.com/polkadot-js/common/issues/1975
  */
 const isNode22 = typeof process !== 'undefined' && parseInt(process.versions?.node?.split('.')[0] || '0', 10) >= 22;
 

--- a/packages/x-ws/src/node.ts
+++ b/packages/x-ws/src/node.ts
@@ -7,4 +7,14 @@ import { extractGlobal } from '@polkadot/x-global';
 
 export { packageInfo } from './packageInfo.js';
 
-export const WebSocket = /*#__PURE__*/ extractGlobal('WebSocket', ws);
+/**
+ * The built-in `globalThis.WebSocket` in Node.js 22+ does not provide
+ * detailed error messages (e.g., `ECONNREFUSED` or `ETIMEDOUT`), making
+ * it difficult to implement proper reconnection logic.
+ *
+ * To avoid these issues, we explicitly use the `ws` library in Node.js 22+
+ * while still preserving support for the browser WebSocket API in browser environments.
+ */
+const isNode22 = typeof process !== 'undefined' && parseInt(process.versions?.node?.split('.')[0] || '0', 10) >= 22;
+
+export const WebSocket = isNode22 ? ws : /*#__PURE__*/ extractGlobal('WebSocket', ws);


### PR DESCRIPTION
Addresses #1975. Starting from Node.js 22, the built in WebSocket implementation does not provide detailed error messages (e.g., `ECONNREFUSED`, `ETIMEDOUT`). This can cause issues when handling disconnections and reconnections in `polkadot-js/api`, as the errors are too generic to detect connection failures properly.

This PR forces the use of the ws library in Node.js 22+. This temporarily fixes the issue, until the  Node.js native WebSocket become mature enough to handle such errors.