### PR TITLE
Cast ws as global.WebSocket

### DIFF
--- a/packages/x-ws/src/node.ts
+++ b/packages/x-ws/src/node.ts
@@ -19,4 +19,4 @@ export { packageInfo } from './packageInfo.js';
  */
 const isNode22 = typeof process !== 'undefined' && parseInt(process.versions?.node?.split('.')[0] || '0', 10) >= 22;
 
-export const WebSocket = isNode22 ? ws : /*#__PURE__*/ extractGlobal('WebSocket', ws);
+export const WebSocket = isNode22 ? (ws as unknown as typeof globalThis.WebSocket) : /*#__PURE__*/ extractGlobal('WebSocket', ws);


### PR DESCRIPTION
Fixes an issue where the `WebSocket` type was inconsistently resolved as either the ws library's WebSocket implementation or the native `WebSocket`, leading to type mismatches.