### PR TITLE
Improve objectSpread function property handling

### DIFF
--- a/packages/util/src/object/spread.ts
+++ b/packages/util/src/object/spread.ts
@@ -1,24 +1,34 @@
 // Copyright 2017-2025 @polkadot/util authors & contributors
 // SPDX-License-Identifier: Apache-2.0
-
 /**
  * @name objectSpread
  * @summary Concats all sources into the destination
+ * @description Spreads object properties while maintaining object integrity
  */
 export function objectSpread <T extends object> (dest: object, ...sources: (object | undefined | null)[]): T {
+  const filterProps = new Set(['__proto__', 'constructor', 'prototype']);
+
   for (let i = 0, count = sources.length; i < count; i++) {
     const src = sources[i];
 
     if (src) {
       if (typeof (src as Map<string, unknown>).entries === 'function') {
         for (const [key, value] of (src as Map<string, unknown>).entries()) {
-          (dest as Record<string, unknown>)[key] = value;
+          if (!filterProps.has(key)) {
+            (dest as Record<string, unknown>)[key] = value;
+          }
         }
       } else {
-        Object.assign(dest, src);
+        // Create a clean copy of the source object
+        const sanitizedSrc = Object.create(null);
+        for (const [key, value] of Object.entries(src)) {
+          if (!filterProps.has(key)) {
+            sanitizedSrc[key] = value;
+          }
+        }
+        Object.assign(dest, sanitizedSrc);
       }
     }
   }
-
   return dest as T;
 }

--- a/packages/util/src/object/spread.ts
+++ b/packages/util/src/object/spread.ts
@@ -1,5 +1,6 @@
 // Copyright 2017-2025 @polkadot/util authors & contributors
 // SPDX-License-Identifier: Apache-2.0
+
 /**
  * @name objectSpread
  * @summary Concats all sources into the destination
@@ -20,15 +21,18 @@ export function objectSpread <T extends object> (dest: object, ...sources: (obje
         }
       } else {
         // Create a clean copy of the source object
-        const sanitizedSrc = Object.create(null);
+        const sanitizedSrc = Object.create(null) as Record<string, unknown>;
+
         for (const [key, value] of Object.entries(src)) {
           if (!filterProps.has(key)) {
             sanitizedSrc[key] = value;
           }
         }
+
         Object.assign(dest, sanitizedSrc);
       }
     }
   }
+
   return dest as T;
 }


### PR DESCRIPTION
This PR updates the `objectSpread` function to better handle special object properties. The changes include:

- Added property filtering to maintain consistent object structure
- Improved handling of Map and regular object sources
- Enhanced object property copying mechanism
- Updated documentation to reflect the new behavior

These changes ensure more predictable object property spreading behavior across different input types.