### PR TITLE
Set pbkdf2Encode rounds to default to 210,000

### DIFF
--- a/packages/util-crypto/src/pbkdf2/encode.ts
+++ b/packages/util-crypto/src/pbkdf2/encode.ts
@@ -15,7 +15,7 @@ interface Result {
   salt: Uint8Array;
 }
 
-export function pbkdf2Encode (passphrase?: string | Uint8Array, salt: Uint8Array = randomAsU8a(), rounds = 2048, onlyJs?: boolean): Result {
+export function pbkdf2Encode (passphrase?: string | Uint8Array, salt: Uint8Array = randomAsU8a(), rounds = 210000, onlyJs?: boolean): Result {
   const u8aPass = u8aToU8a(passphrase);
   const u8aSalt = u8aToU8a(salt);
 


### PR DESCRIPTION
In line with https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2 - set the default rounds to 210_000.

## Why 210,000?:

We pass in `Sha512` for `pbkdf2Js` from `@noble/hashes`
By default `pbkdf2` from `@polkadot/wasm-crypto` uses `HMAC-SHA512`.