### PR TITLE
Add input length validation in `scryptFromU8a` function

### DIFF
--- a/packages/util-crypto/src/scrypt/fromU8a.ts
+++ b/packages/util-crypto/src/scrypt/fromU8a.ts
@@ -14,6 +14,11 @@ interface Result {
 }
 
 export function scryptFromU8a (data: Uint8Array): Result {
+  // Ensure the input is exactly 44 bytes: 32 for salt + 3 * 4 for N, p, r
+  if (data.length !== 32 + 12) {
+    throw new Error(`Invalid input length: expected 44 bytes, found ${data.length}`);
+  }
+
   const salt = data.subarray(0, 32);
   const N = u8aToBn(data.subarray(32 + 0, 32 + 4), BN_LE_OPTS).toNumber();
   const p = u8aToBn(data.subarray(32 + 4, 32 + 8), BN_LE_OPTS).toNumber();

--- a/packages/util-crypto/src/scrypt/fromU8a.ts
+++ b/packages/util-crypto/src/scrypt/fromU8a.ts
@@ -14,8 +14,12 @@ interface Result {
 }
 
 export function scryptFromU8a (data: Uint8Array): Result {
+   if (!(data instanceof Uint8Array)) {
+    throw new Error('Expected input to be a Uint8Array');
+  }
+
   // Ensure the input is exactly 44 bytes: 32 for salt + 3 * 4 for N, p, r
-  if (data.length !== 32 + 12) {
+  if (data.length < 32 + 12) {
     throw new Error(`Invalid input length: expected 44 bytes, found ${data.length}`);
   }
 


### PR DESCRIPTION
## 📝 Description

This PR addresses unsafe parsing in `scryptFromU8a` (`packages/util-crypto/src/scrypt/fromU8a.ts`), where scrypt parameters (`N`, `p`, `r`) are extracted using hardcoded offsets without validation. This approach assumes a fixed binary layout and lacks structure or integrity checks, making it fragile and error-prone.

We currently reject any non-default values, limiting flexibility and introducing risk if malformed data is parsed. Future improvements should define a strict format and allow safe, validated parameter overrides.