### PR TITLE
Update polkadot dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:one": "polkadot-dev-run-test --env browser"
   },
   "devDependencies": {
-    "@polkadot/dev": "^0.83.2",
+    "@polkadot/dev": "^0.83.3",
     "@types/node": "^22.7.5"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,34 +1478,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/dev-test@npm:^0.83.2":
-  version: 0.83.2
-  resolution: "@polkadot/dev-test@npm:0.83.2"
+"@polkadot/dev-test@npm:^0.83.3":
+  version: 0.83.3
+  resolution: "@polkadot/dev-test@npm:0.83.3"
   dependencies:
     jsdom: "npm:^24.0.0"
     tslib: "npm:^2.7.0"
-  checksum: 10/afe60165272a09d5c9f08e3aec0015621350dc7394ee8ff121d5803c576c7601b176b753716203abba4a81a142b529da066fe4c73f39387b018bdde69fef7a10
+  checksum: 10/c03e0c5c5c5d22394c63948b35157b97f8f734a6a8403c89990c55b2657f2b284996aef8613815b2b576b271a126244d7f0a2c9ddece438c5799f273be2e1c69
   languageName: node
   linkType: hard
 
-"@polkadot/dev-ts@npm:^0.83.2":
-  version: 0.83.2
-  resolution: "@polkadot/dev-ts@npm:0.83.2"
+"@polkadot/dev-ts@npm:^0.83.3":
+  version: 0.83.3
+  resolution: "@polkadot/dev-ts@npm:0.83.3"
   dependencies:
     json5: "npm:^2.2.3"
     tslib: "npm:^2.7.0"
     typescript: "npm:^5.5.4"
-  checksum: 10/abca4df87a0682285bf5e5644ab8522820d53e0dffc124bfe540b7fccc55532057d1912629584bb04648e855e110896b36e55536d53556a166fc3d33bcc27b39
+  checksum: 10/a2ddc4dba934758cc24f02e8acbfa5a5f5295ad874f42c1bea8548a6dfa97c882b127a279001831caedc8d474becb905286847e0f64e8efe7063b6bac4830112
   languageName: node
   linkType: hard
 
-"@polkadot/dev@npm:^0.83.2":
-  version: 0.83.2
-  resolution: "@polkadot/dev@npm:0.83.2"
+"@polkadot/dev@npm:^0.83.3":
+  version: 0.83.3
+  resolution: "@polkadot/dev@npm:0.83.3"
   dependencies:
     "@eslint/js": "npm:^8.56.0"
-    "@polkadot/dev-test": "npm:^0.83.2"
-    "@polkadot/dev-ts": "npm:^0.83.2"
+    "@polkadot/dev-test": "npm:^0.83.3"
+    "@polkadot/dev-ts": "npm:^0.83.3"
     "@rollup/plugin-alias": "npm:^5.1.1"
     "@rollup/plugin-commonjs": "npm:^25.0.8"
     "@rollup/plugin-dynamic-import-vars": "npm:^2.1.5"
@@ -1570,7 +1570,7 @@ __metadata:
     polkadot-exec-rollup: scripts/polkadot-exec-rollup.mjs
     polkadot-exec-tsc: scripts/polkadot-exec-tsc.mjs
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.mjs
-  checksum: 10/42a67e0f2401fc13bdffff86398958e326613461eaa294fb5b435037d636b94cbbbce81b1fadbdf3c0553798d3bc5df43ef6af2250f75e312f01e52b665eddfe
+  checksum: 10/f34171f4776f0ade59e750e6c43db56fccc800e5c5c2e7796299e83072534257fa5e7478b8159a4b265e96d36c9fe380d56326c21cdbdf51dda3221c269601be
   languageName: node
   linkType: hard
 
@@ -10741,7 +10741,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@polkadot/dev": "npm:^0.83.2"
+    "@polkadot/dev": "npm:^0.83.3"
     "@types/node": "npm:^22.7.5"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description
```
   @ledgerhq/hw-transport-node-hid-singleton --- ◉ ^6.31.5 ------ ◯ ^6.31.8 ------
   @ledgerhq/hw-transport-webhid --------------- ◉ ^6.29.4 ------ ◯ ^6.30.3 ------
   @ledgerhq/hw-transport-webusb --------------- ◉ ^6.29.4 ------ ◯ ^6.29.7 ------
   @ledgerhq/hw-transport ---------------------- ◉ ^6.31.4 ------ ◯ ^6.31.7 ------
   @noble/curves ------------------------------- ◉ ^1.3.0 ------- ◯ ^1.9.2 -------
   @noble/hashes ------------------------------- ◉ ^1.3.3 ------- ◯ ^1.8.0 -------
 > @polkadot/dev ------------------------------- ◯ ^0.83.2 ------ ◉ ^0.83.3 ------
   @scure/base --------------------------------- ◉ ^1.1.7 ------- ◯ ^1.2.6 -------
   @types/bn.js -------------------------------- ◉ ^5.1.6 ------- ◯ ^5.2.0 -------
   @types/node --------------------------------- ◉ ^22.7.5 ------ ◯ ^22.15.34 ---- ◯ ^24.0.8 ------
   @types/ws ----------------------------------- ◉ ^8.5.12 ------ ◯ ^8.18.1 ------
   @zondax/ledger-substrate -------------------- ◉ 1.1.1 -------- ◯ 1.1.2 --------
   bn.js --------------------------------------- ◉ ^5.2.1 ------- ◯ ^5.2.2 -------
   tslib --------------------------------------- ◉ ^2.8.0 ------- ◯ ^2.8.1 -------
   ws ------------------------------------------ ◉ ^8.18.0 ------ ◯ ^8.18.3 ------
   ```