### PR TITLE
Fix(hw-ledger): reset transport on operation errors and add explicit disconnect API

### DIFF
--- a/packages/hw-ledger/src/Ledger.ts
+++ b/packages/hw-ledger/src/Ledger.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SubstrateApp } from '@zondax/ledger-substrate';
-import type { TransportDef, TransportType } from '@polkadot/hw-ledger-transports/types';
+import type { Transport, TransportDef, TransportType } from '@polkadot/hw-ledger-transports/types';
 import type { AccountOptions, LedgerAddress, LedgerSignature, LedgerVersion } from './types.js';
 
 import { newSubstrateApp } from '@zondax/ledger-substrate';
@@ -28,6 +28,17 @@ async function wrapError <T extends WrappedResult> (promise: Promise<T>): Promis
   }
 
   return result;
+}
+
+/** @internal Best-effort transport cleanup after failed operations */
+async function closeTransport (transport: Transport | null): Promise<void> {
+  if (transport) {
+    try {
+      await transport.close();
+    } catch {
+      // Ignore cleanup errors so the original failure is preserved.
+    }
+  }
 }
 
 /** @internal Wraps a sign/signRaw call and returns the associated signature */
@@ -121,9 +132,11 @@ export class Ledger {
    * this is only used internally, to ensure consistent bahavior.
    */
   async withApp <T> (fn: (app: SubstrateApp) => Promise<T>): Promise<T> {
+    let transport: Transport | null = null;
+
     try {
       if (!this.#app) {
-        const transport = await this.#transportDef.create();
+        transport = await this.#transportDef.create();
 
         // We need this override for the actual type passing - the Deno environment
         // is quite a bit stricter and it yields invalids between the two (specifically
@@ -136,6 +149,7 @@ export class Ledger {
 
       return await fn(this.#app);
     } catch (error) {
+      await closeTransport(this.#app?.transport || transport);
       this.#app = null;
 
       throw error;

--- a/packages/hw-ledger/src/Ledger.ts
+++ b/packages/hw-ledger/src/Ledger.ts
@@ -126,10 +126,21 @@ export class Ledger {
   }
 
   /**
+   * Closes any active transport connection
+   */
+  public async disconnect (): Promise<void> {
+    const app = this.#app;
+
+    this.#app = null;
+
+    await closeTransport(app?.transport || null);
+  }
+
+  /**
    * @internal
    *
    * Returns a created SubstrateApp to perform operations against. Generally
-   * this is only used internally, to ensure consistent bahavior.
+   * this is only used internally, to ensure consistent behavior.
    */
   async withApp <T> (fn: (app: SubstrateApp) => Promise<T>): Promise<T> {
     let transport: Transport | null = null;

--- a/packages/hw-ledger/src/LedgerGeneric.ts
+++ b/packages/hw-ledger/src/LedgerGeneric.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2026 @polkadot/hw-ledger authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { TransportDef, TransportType } from '@polkadot/hw-ledger-transports/types';
+import type { Transport, TransportDef, TransportType } from '@polkadot/hw-ledger-transports/types';
 import type { AccountOptionsGeneric, LedgerAddress, LedgerSignature, LedgerVersion } from './types.js';
 
 import { PolkadotGenericApp } from '@zondax/ledger-substrate';
@@ -44,6 +44,17 @@ async function wrapError <T extends WrappedResult> (promise: Promise<T>): Promis
   }
 
   return result;
+}
+
+/** @internal Best-effort transport cleanup after failed operations */
+async function closeTransport (transport: Transport | null): Promise<void> {
+  if (transport) {
+    try {
+      await transport.close();
+    } catch {
+      // Ignore cleanup errors so the original failure is preserved.
+    }
+  }
 }
 
 /** @internal Wraps a signEd25519/signRawEd25519 call and returns the associated signature */
@@ -252,9 +263,11 @@ export class LedgerGeneric {
    * this is only used internally, to ensure consistent bahavior.
    */
   async withApp <T> (fn: (app: PolkadotGenericApp) => Promise<T>): Promise<T> {
+    let transport: Transport | null = null;
+
     try {
       if (!this.#app) {
-        const transport = await this.#transportDef.create();
+        transport = await this.#transportDef.create();
 
         // We need this override for the actual type passing - the Deno environment
         // is quite a bit stricter and it yields invalids between the two (specifically
@@ -267,6 +280,7 @@ export class LedgerGeneric {
 
       return await fn(this.#app);
     } catch (error) {
+      await closeTransport(this.#app?.transport || transport);
       this.#app = null;
 
       throw error;

--- a/packages/hw-ledger/src/LedgerGeneric.ts
+++ b/packages/hw-ledger/src/LedgerGeneric.ts
@@ -33,7 +33,7 @@ async function wrapError <T extends WrappedResult> (promise: Promise<T>): Promis
   try {
     result = await promise;
   } catch (e: unknown) {
-    // We check to see if the propogated error is the newer ResponseError type.
+    // We check to see if the propagated error is the newer ResponseError type.
     // The response code use to be part of the result, but with the latest breaking changes from 0.42.x
     // the interface and it's types have completely changed.
     if ((e as ResponseError).returnCode) {
@@ -254,6 +254,17 @@ export class LedgerGeneric {
    */
   public async signWithMetadataEcdsa (message: Uint8Array, accountIndex?: number, addressOffset?: number, options?: Partial<AccountOptionsGeneric>) {
     return this.withApp(signWithMetadataEcdsa(message, this.#slip44, accountIndex, addressOffset, options));
+  }
+
+  /**
+   * Closes any active transport connection
+   */
+  public async disconnect (): Promise<void> {
+    const app = this.#app;
+
+    this.#app = null;
+
+    await closeTransport(app?.transport || null);
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR updates hw-ledger transport lifecycle handling in two places:

- close/reset the active transport when a `withApp` operation fails
- add an explicit `disconnect()` method on `Ledger` and `LedgerGeneric` so consumers can clean up intentionally

## Why
While testing extension flows, I kept hitting transport/session problems after failures and across hook lifecycles:

- if an operation fails, keeping the same app/transport around can cause follow-up errors and inconsistent state
- consumers need a reliable way to release an active transport during lifecycle transitions (unmount, refresh, replacing an instance)

Related context:
- https://github.com/polkadot-js/extension/issues/1610
- https://github.com/polkadot-js/extension/pull/1611

Behavior:
- on `withApp` error: best-effort `transport.close()`, clear cached app, rethrow original error
- `disconnect()`: explicit consumer API to close an active transport without waiting for an internal failure path

## Why `disconnect()` is needed
In `useLedger`-style flows, one hook instance can unmount while its transport is still open.  
The next instance may then fail with “already open” transport errors.  
`disconnect()` gives consumers a clean, explicit teardown point to avoid that.

## Compatibility / risk
- error-path behavior is intentionally stricter: failed operations now reset transport state instead of leaving a possibly bad session alive